### PR TITLE
Add evidence taxonomy and source brief standard

### DIFF
--- a/evidence/README.md
+++ b/evidence/README.md
@@ -1,0 +1,54 @@
+# Evidence Library
+
+This directory separates empirical sources from the report's interpretation and from the repository's operational protocols.
+
+The goal is not to flatten every source into a single confidence level. Different materials answer different questions and support different kinds of claims.
+
+## Evidence classes
+
+### [Primary empirical research](primary/README.md)
+Original studies, working papers, controlled experiments, and large-scale observational analyses that directly report methods and results.
+
+Use these sources for claims about measured effects. Record the publication status, dataset, method, directly observed findings, model-derived estimates, and limitations.
+
+### [Secondary evidence](secondary/README.md)
+Industry reports, practitioner analyses, replications, reviews, and other materials that synthesize or interpret primary data.
+
+Use these sources for triangulation and context, not as substitutes for the underlying study when the primary source is available.
+
+### [Datasets](datasets/README.md)
+Public or documented datasets used by cited research or maintained for independent analysis.
+
+Dataset entries should describe provenance, coverage, known transformations, access conditions, and the claims the data can and cannot support.
+
+## Relationship to the rest of the repository
+
+- `report/` contains the Subprime Code Crisis argument and synthesis.
+- `protocols/` contains operational responses and decision rules.
+- `evidence/` contains source-oriented briefs that distinguish reported findings from repository interpretation.
+- `REFERENCES.md` remains the compact bibliography and navigation index.
+
+## Evidence brief standard
+
+Each evidence brief should include:
+
+1. Full citation and source links.
+2. Publication status, including whether the work is peer reviewed.
+3. Research question and scope.
+4. Dataset and methodology.
+5. Directly observed findings.
+6. Model-calibrated or derived findings.
+7. Interpretation relevant to this repository.
+8. What the source does not establish.
+9. Limitations and external-validity risks.
+10. Links to any local source copy retained in the repository.
+
+## Interpretation labels
+
+Use these labels where useful:
+
+- **Observed:** directly reported from the study's empirical analysis.
+- **Derived:** calculated from reported results without adding a new causal claim.
+- **Model-calibrated:** produced by a fitted or calibrated model rather than directly measured.
+- **Repository interpretation:** the Subprime Code Crisis project's synthesis or application of the evidence.
+- **Not established:** a plausible claim that the source does not itself demonstrate.

--- a/evidence/datasets/README.md
+++ b/evidence/datasets/README.md
@@ -1,0 +1,16 @@
+# Datasets
+
+This directory documents datasets used by cited studies or retained for independent analysis.
+
+A dataset entry should record:
+
+- owner and provenance;
+- collection period and population;
+- unit of analysis;
+- inclusion and exclusion rules;
+- transformations or derived fields;
+- access and licensing conditions;
+- known missingness and bias;
+- the claims the dataset can and cannot support.
+
+Do not commit restricted, personal, proprietary, or ambiguously licensed data. When a dataset cannot be redistributed, provide metadata and an authoritative access link instead.

--- a/evidence/primary/README.md
+++ b/evidence/primary/README.md
@@ -1,0 +1,15 @@
+# Primary Empirical Research
+
+This directory contains evidence briefs for original empirical studies.
+
+Eligible materials include:
+
+- peer-reviewed research;
+- working papers with disclosed methods;
+- randomized or controlled experiments;
+- large-scale observational studies;
+- original measurement reports with inspectable methodology.
+
+A source's inclusion here does not imply that every claim in the source is correct or that its results generalize universally. Each brief must state publication status, research design, scope, measured findings, model-derived findings, and limitations.
+
+Do not place the repository's own conclusions in this directory unless they are clearly labeled as **repository interpretation**.

--- a/evidence/secondary/README.md
+++ b/evidence/secondary/README.md
@@ -1,0 +1,15 @@
+# Secondary Evidence
+
+This directory contains briefs for sources that synthesize, interpret, review, or operationalize primary evidence.
+
+Examples include:
+
+- industry research reports;
+- practitioner analyses;
+- systematic or narrative reviews;
+- replications and critiques;
+- measurement summaries published without access to the full underlying dataset.
+
+Secondary evidence is useful for triangulation, framing, and identifying operational implications. When an original study is available, link to and evaluate the primary source rather than relying only on a summary.
+
+Each brief should identify the underlying primary sources, disclose commercial or institutional interests where relevant, and separate reported facts from the author's interpretation.


### PR DESCRIPTION
## Summary

Introduces a lightweight evidence-library structure before integrating the new NBER source.

### Added

- `evidence/README.md` — taxonomy, repository boundaries, evidence-brief standard, and interpretation labels.
- `evidence/primary/README.md` — criteria for original empirical research.
- `evidence/secondary/README.md` — criteria for industry reports, reviews, replications, and practitioner synthesis.
- `evidence/datasets/README.md` — dataset provenance, licensing, coverage, and limitation requirements.

## Why this comes first

The repository currently combines research findings, project interpretation, and operational protocols. This structure makes those layers explicit without changing the existing report or manifesto tone.

The following NBER PR will use the primary-research brief standard established here.

## Scope boundaries

This PR does not:

- modify the report;
- modify protocols;
- change existing claims;
- add the NBER paper itself;
- alter the DOU article.

## Review focus

Please review whether the taxonomy is clear enough to distinguish:

1. directly observed findings;
2. derived or model-calibrated results;
3. repository interpretation;
4. claims not established by a source.