### PR TITLE
Integrate the four-layer operational protocol stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ It can be read in three ways:
 
 Readers looking for the evidence base should start with the [Evidence Library](evidence/README.md) and then use [References](REFERENCES.md) as the complete bibliography and compact source index.
 
-Readers looking for immediate operating practices should start with the Risk Mitigation section.
+Readers looking for immediate operating practices should start with the [Operational Protocols](protocols/README.md).
 ## 📂 Report Structure
 
 The analysis is divided into three parts, covering the data, the mechanics of the failure, and the projected economic outcomes.
@@ -189,9 +189,24 @@ The analysis is divided into three parts, covering the data, the mechanics of th
 
 ## 🛡️ Risk Mitigation
 
-For engineering leaders and practitioners, this repository includes operational protocols for reducing the risks identified in the report.
+The repository's operational response is organized as a four-layer control stack:
 
-These are practical operating measures for teams that want to adopt AI-assisted development without overwhelming code review, QA, security, architecture, and maintenance capacity.
+```mermaid
+flowchart LR
+    A[Engineer<br/>Boundaries and verification]
+    --> B[Team<br/>Metrics, gates, escalation]
+    --> C[Public evidence<br/>Disclosure and correction]
+    --> D[Organization<br/>Ownership, policy, capacity]
+```
+
+| Layer | Protocol | Primary question |
+| --- | --- | --- |
+| **Engineer** | [Personal Defense](protocols/01_personal_defense.md) | What generated output may cross into durable code, and under what verification? |
+| **Team** | [Operational Defense](protocols/02_operational_defense.md) | Is local acceleration improving or degrading delivery-system outcomes? |
+| **Public evidence** | [Public Evidence and Disclosure](protocols/03_public_defense.md) | What can be claimed, with what support, limitations, and correction path? |
+| **Organization** | [Systemic Cure](protocols/04_systemic_cure.md) | Who owns adoption policy, capacity, exceptions, escalation, and learning? |
+
+These are practical operating patterns, not universal thresholds or empirical proof. Teams should adapt them to local risk, architecture, regulation, and delivery constraints, then feed implementation results back into the evidence base.
 
 👉 **[ACCESS OPERATIONAL PROTOCOLS](protocols/README.md)**
 

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -1,58 +1,132 @@
-# 🛡️ Defense Protocols: Information Defense
+# 🛡️ Operational Protocols
 
 > **Navigation:** [🏠 Home](../README.md) | [📉 The Report](../report/01_the_illusion.md) | **Protocols** | [📚 References](../REFERENCES.md)
-> > 
-## Operational Protocols
 
-These protocols are practical operating patterns for teams adopting AI-assisted software development.
+## From diagnosis to operating practice
 
-They are not intended to discourage AI adoption. Their purpose is to help teams absorb AI-generated output safely by strengthening review capacity, QA signals, architectural ownership, security validation, and feedback loops.
+These protocols translate the repository's delivery-system risk analysis into practical controls for AI-assisted software development.
 
-Use them as adaptation patterns, not as rigid rules.
+They are not empirical proof and they are not universal policy. They are operating patterns that teams and organizations can adapt to their own architecture, risk profile, regulatory obligations, and delivery constraints.
 
-## The Counter-Measure: Breaking the "Speed" Hallucination
+The four protocols form one control stack:
 
-The AI circus has been going on for too long, and frankly, the **hype is exhausting**. But beneath the noise lies a cold, dangerous reality: the potential for a systemic crash is growing every day.
+```mermaid
+flowchart TD
+    A[Protocol 1: Engineer boundary<br/>Contain, reference, verify]
+    --> B[Protocol 2: Team control loop<br/>Measure, gate, escalate]
+    --> C[Protocol 3: Evidence disclosure<br/>Bound, trace, correct]
+    --> D[Protocol 4: Organizational control model<br/>Own, govern, learn]
+```
 
-We do not want the industry to wake up only after the companies we work for collapse under the weight of unmanageable technical debt.
-
-**Silence is validation.** Every time we stay silent during a meeting where "AI Velocity" is praised without context, we are complicit in the degradation of our craft.
-
-If you agree that **Engineering Velocity ≠ Typing Speed**, you have a role to play in correcting the narrative. These protocols are your toolkit for **Information Defense**.
-
----
-
-## 📂 Protocol Library
-
-### [Protocol 1: The Personal Defense (For Engineers)](01_personal_defense.md)
-*   **Target:** Senior Engineers, Tech Leads, Developers.
-*   **The Stance:** Master the Tool, Don't Serve It.
-*   **Action:** Implement the "Green/Red Zone" containment strategy and refuse to normalize "coding by probability."
-
-### [Protocol 2: The Operational Defense (For Managers)](02_operational_defense.md)
-*   **Target:** Engineering Managers, VP of Engineering.
-*   **The Stance:** Measure Health, Not Hype.
-*   **Action:** Stop tracking "Lines of Code." Start tracking Code Churn, Defect Escape Rate, and Review Bottlenecks.
-
-### [Protocol 3: The Public Defense (For Advocates)](03_public_defense.md)
-*   **Target:** Everyone.
-*   **The Stance:** Correct the Market Narrative.
-*   **Action:** Use these scripts to push back against "Placebo Analytics" in Slack, Teams, and LinkedIn.
-
-### [Protocol 4: The Systemic Cure (For Builders)](04_systemic_cure.md)
-*   **Target:** Architects, Platform Engineers, CTOs.
-*   **The Stance:** Govern Uncertainty.
-*   **Action:** Re-architect the SDLC using "Uncertainty Architecture" and Control Planes.
+Each layer addresses a different failure mode. None of them is sufficient alone.
 
 ---
 
-## 🏁 Final Word
+## Protocol library
 
-The "AI Revolution" will not be defined by how fast we can generate text. It will be defined by how well we can **govern uncertainty**.
+### [Protocol 1: Personal Defense](01_personal_defense.md)
 
-Don't let the hype cycle destroy your codebase.
+**Primary users:** Engineers, senior engineers, tech leads, reviewers.
 
-**Read. Verify. Push Back.**
+**Purpose:** Protect the individual engineering decision boundary.
+
+**Core controls:**
+
+- Green, Controlled, and Protected work zones;
+- Disposable Boundary Pattern;
+- Reference-Bounded Adaptation;
+- explicit verification before generated output becomes durable code;
+- engineer accountability for every committed change.
+
+**Use this when:** AI-generated output is entering day-to-day implementation work and the team needs clear boundaries for what may be generated, adapted, reviewed, or rejected.
 
 ---
+
+### [Protocol 2: Operational Defense](02_operational_defense.md)
+
+**Primary users:** Engineering managers, delivery leaders, QA leaders, architects, platform teams.
+
+**Purpose:** Turn AI-assisted development into a measurable team-level control loop.
+
+**Core controls:**
+
+- local baselines rather than universal thresholds;
+- flow, review, rework, quality, release, and production signals;
+- change-risk classes and minimum review gates;
+- investigate, constrain, and pause escalation rules;
+- recurring operating review and decision records.
+
+**Use this when:** A team or pilot is adopting AI assistance and needs to determine whether local acceleration survives review, validation, release, and production use.
+
+---
+
+### [Protocol 3: Public Evidence and Disclosure](03_public_defense.md)
+
+**Primary users:** Engineering leaders, researchers, vendors, analysts, internal communications teams, public advocates.
+
+**Purpose:** Make claims about AI-assisted software delivery inspectable, bounded, and correctable.
+
+**Core controls:**
+
+- separation of tool activity, workflow effects, production outcomes, and causal interpretation;
+- claim classification and minimum support expectations;
+- public disclosure and minimum disclosure templates;
+- source traceability and explicit limitations;
+- anti-hype rules and a correction protocol.
+
+**Use this when:** Publishing a benchmark, case study, executive claim, adoption result, vendor statement, internal update, or criticism of AI-assisted development.
+
+---
+
+### [Protocol 4: Systemic Cure](04_systemic_cure.md)
+
+**Primary users:** CTOs, engineering executives, architects, platform leaders, security and governance owners.
+
+**Purpose:** Establish an organizational operating model for governing AI-assisted software delivery as a system change.
+
+**Core controls:**
+
+- organizational control plane;
+- named ownership and decision rights;
+- executable policy lifecycle;
+- review, QA, security, architecture, release, and maintenance capacity planning;
+- staged adoption gates;
+- exception debt, decision memory, and incident learning.
+
+**Use this when:** AI adoption is expanding beyond a local team and the organization needs consistent policy, capacity, accountability, and feedback loops.
+
+---
+
+## How to apply the stack
+
+Do not begin with organization-wide policy and assume the lower layers will follow automatically.
+
+A practical adoption sequence is:
+
+1. Establish engineer-level boundaries and verification practices.
+2. Pilot a team-level control loop with local baselines and explicit gates.
+3. Communicate results through bounded, traceable disclosures.
+4. Expand only when organizational ownership, capacity, policy, and pause authority exist.
+
+The reverse sequence is a common failure mode: executives announce broad adoption, teams absorb the output, reviewers become the hidden constraint, and governance is added only after defects or maintenance costs appear.
+
+---
+
+## Evidence boundary
+
+These protocols are derived from the report's risk analysis and evidence synthesis. They should be evaluated through implementation feedback, local measurement, and further empirical study.
+
+- The [Evidence Library](../evidence/README.md) documents source classes and evidence briefs.
+- The [Claim confidence map](../README.md#claim-confidence-map) identifies the current support level of major repository claims.
+- [References](../REFERENCES.md) remains the complete bibliography and compact source inventory.
+- [Uncertainty Architecture](https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture) provides a broader specification for governing non-deterministic systems; it complements this repository but does not replace these software-delivery protocols.
+
+---
+
+## Operating principle
+
+> Faster generation is useful only when the surrounding system can still understand, verify, release, operate, and maintain the result.
+
+---
+
 *License: CC-BY-SA 4.0*


### PR DESCRIPTION
## Summary

Completes the protocol rewrite series by aligning the repository entry points with the new four-layer operating model.

## Changes

### `protocols/README.md`

- replaces the old "Information Defense" and campaign framing;
- presents the protocols as one control stack:
  - engineer boundary;
  - team control loop;
  - public evidence and disclosure;
  - organizational control model;
- updates each protocol description, audience, purpose, controls, and use case;
- adds a practical adoption sequence;
- adds evidence boundaries and clarifies the relationship to Uncertainty Architecture;
- replaces slogan-driven closing language with an operating principle.

### `README.md`

- links readers directly to the Operational Protocols from the reading guide;
- expands Risk Mitigation into a concise four-layer control map;
- adds a layer-to-protocol table with the primary decision question for each level;
- clarifies that protocols are adaptable operating patterns rather than universal thresholds or empirical proof.

## Scope

This PR modifies only:

- `README.md`
- `protocols/README.md`

It does not change report claims, evidence briefs, references, or the individual protocol documents.

## Review focus

1. Does the repository now present the four protocols as one coherent system?
2. Are the boundaries between engineer, team, public-evidence, and organizational controls clear?
3. Is the distinction between operational guidance and empirical evidence explicit enough?
4. Does the relationship to Uncertainty Architecture remain clear without conflating the two repositories?