### PR TITLE
Unify evidence governance and add agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,219 @@
+# AGENTS.md
+
+## Purpose
+
+This file defines how human contributors and AI agents should read, modify, and extend this repository without mixing evidence, interpretation, and operational guidance.
+
+The repository has four distinct layers:
+
+1. **Evidence** — what external sources actually report.
+2. **Report** — the Subprime Code Crisis synthesis and argument.
+3. **Protocols** — practical controls derived from the risk analysis.
+4. **Repository maps** — navigation, claim confidence, and source indexes.
+
+Do not collapse these layers.
+
+## Read order
+
+Before making changes, read in this order:
+
+1. `README.md` — scope, claim-confidence map, evidence map, and repository structure.
+2. `evidence/README.md` — source taxonomy and evidence-brief standard.
+3. `evidence/SOURCES.md` — canonical source registry and review status.
+4. Relevant evidence brief under `evidence/`.
+5. Relevant chapter under `report/`.
+6. Relevant operational response under `protocols/`.
+7. `CONTRIBUTING.md` — contribution and disclosure requirements.
+
+Use `REFERENCES.md` for human-readable bibliography navigation, not as the canonical source-classification database.
+
+## Repository boundaries
+
+### Evidence layer
+
+Evidence entries describe external material. They must separate:
+
+- directly observed findings;
+- derived calculations;
+- model-calibrated estimates;
+- source-author interpretation;
+- repository interpretation;
+- claims not established by the source;
+- limitations and external-validity risks.
+
+Never write a repository conclusion as though it were a finding reported by a source.
+
+### Report layer
+
+The report may combine multiple sources and systems reasoning. Every material factual claim should trace to:
+
+- a reviewed evidence brief; or
+- a registered source whose brief is explicitly marked pending.
+
+When a source is not strong enough for a causal claim, use bounded language such as `suggests`, `is consistent with`, `may indicate`, or `supports the risk hypothesis`.
+
+### Protocol layer
+
+Protocols are operating patterns, not empirical proof. A protocol may be motivated by evidence and systems analysis, but it must not present a local threshold, role, gate, or workflow as universally validated unless a source directly establishes that claim.
+
+### Repository maps
+
+`README.md`, `evidence/SOURCES.md`, and `REFERENCES.md` must remain mutually consistent:
+
+- `evidence/SOURCES.md` is the canonical registry;
+- evidence subdirectory indexes list reviewed briefs;
+- `REFERENCES.md` is a compact bibliography generated from the registry;
+- `README.md` summarizes source families and major claims.
+
+## Adding a new source
+
+Use this sequence. Do not skip directly to editing the report.
+
+### Step 1 — Register the source
+
+Add the source to `evidence/SOURCES.md` with:
+
+- stable source ID;
+- full title and authors or publishing organization;
+- year and publication status;
+- canonical URL;
+- evidence class;
+- current review status;
+- report locations where it is used or proposed;
+- short note on what it can support.
+
+Use IDs in the form:
+
+- `P-YYYY-NN` — primary empirical research;
+- `D-YYYY-NN` — primary documentary source;
+- `S-YYYY-NN` — secondary evidence;
+- `M-YYYY-NN` — methodology or theory;
+- `DS-YYYY-NN` — dataset.
+
+### Step 2 — Classify it
+
+Choose exactly one primary class:
+
+- `evidence/primary/` — original empirical research or original measurement with inspectable methods;
+- `evidence/documentary/` — first-party filings, official documentation, standards, and organizational records;
+- `evidence/secondary/` — surveys, reviews, practitioner analysis, critiques, and industry synthesis;
+- `evidence/methodology/` — theories and analytical frameworks used to interpret evidence;
+- `evidence/datasets/` — datasets and data registries.
+
+Classification describes what the source is, not whether its conclusions are favorable to the repository thesis.
+
+### Step 3 — Create an evidence brief
+
+Create a kebab-case Markdown file in the correct evidence directory. Include:
+
+1. Source ID and full citation.
+2. Publication status.
+3. Research question or documentary purpose.
+4. Scope, dataset, and methodology where applicable.
+5. Directly observed or documented findings.
+6. Derived or model-calibrated findings.
+7. Repository-relevant interpretation.
+8. What the source does not establish.
+9. Limitations, conflicts of interest, and external-validity risks.
+10. Links to report sections using the source.
+
+A source may be registered before the brief is complete, but it must be marked `Brief pending` and should not become a load-bearing source for a strong claim.
+
+### Step 4 — Update the evidence index
+
+Add the reviewed brief to the relevant directory `README.md` and change its status in `evidence/SOURCES.md` to `Reviewed brief`.
+
+### Step 5 — Integrate it into the report
+
+Edit only the chapter where the source materially changes the argument.
+
+For each integration:
+
+- state what the source actually measured;
+- separate findings from repository inference;
+- link to the evidence brief;
+- add visible limitations where the finding could be overgeneralized;
+- remove or weaken older claims if the new source contradicts them.
+
+Do not add a source merely as citation decoration.
+
+### Step 6 — Reassess repository-level claims
+
+Update `README.md` only when the new source changes:
+
+- the claim-confidence map;
+- the evidence map coverage;
+- the executive summary;
+- a major repository-level conclusion.
+
+Do not update the README for every minor source.
+
+### Step 7 — Reassess protocols
+
+Update protocols only when the evidence changes an operational decision, such as:
+
+- a risk boundary;
+- a metric definition;
+- a gate;
+- an escalation rule;
+- a disclosure requirement;
+- an organizational control.
+
+New evidence does not automatically require a protocol change.
+
+### Step 8 — Update bibliography and navigation
+
+After the source is registered and integrated:
+
+- update `REFERENCES.md`;
+- verify links from the relevant evidence index;
+- verify links from report sections;
+- verify navigation in any changed files.
+
+## Updating an existing source
+
+When a working paper becomes peer reviewed, a report is revised, or a dataset changes:
+
+1. Update `evidence/SOURCES.md`.
+2. Update the evidence brief and clearly note the new version.
+3. Recheck every report claim that uses the source.
+4. Reassess claim confidence.
+5. Update `REFERENCES.md`.
+6. Record corrections rather than silently preserving obsolete numbers.
+
+## Evidence-strength rules
+
+- Prefer the primary source over summaries when available.
+- Prefer official publisher or author links over reposts.
+- Do not infer causality from descriptive or observational evidence without explicit justification.
+- Do not present self-reported adoption or sentiment as production impact.
+- Do not treat arXiv status as peer review.
+- Do not treat company marketing as independent evidence.
+- Do not use one team's threshold as a universal standard.
+- Preserve null, mixed, and contradictory results.
+
+## Change checklist
+
+Before opening a PR, confirm:
+
+- [ ] The source is registered in `evidence/SOURCES.md`.
+- [ ] Its evidence class is correct.
+- [ ] Findings and repository interpretation are separated.
+- [ ] Publication status is explicit.
+- [ ] Strong claims link to reviewed briefs where possible.
+- [ ] Report language matches the source design.
+- [ ] README claim confidence was reassessed.
+- [ ] Protocol implications were considered but not forced.
+- [ ] `REFERENCES.md` and indexes are synchronized.
+- [ ] Navigation links work.
+- [ ] The PR description lists evidence boundaries and what the source does not establish.
+
+## Preferred PR structure
+
+For a substantial new source, use separate PRs when practical:
+
+1. source registration and evidence brief;
+2. report integration;
+3. repository-map or protocol updates, only if needed.
+
+This keeps evidence review separate from argument and policy changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,125 @@
-# Contributing to the Subprime Code Crisis Report
+# Contributing to the Subprime Code Crisis
 
-> **"We are the architects of logic, not consumers of syntax."**
+This repository is an independent research synthesis and operational guidance project about AI-assisted software-delivery risk.
 
-This repository is not just a report; it is a living document of the software industry's struggle against unmanaged complexity. We welcome contributions from engineers, researchers, and leaders who value **Engineering Velocity** over **Typing Speed**.
+Contributions are welcome from engineers, researchers, delivery leaders, QA and security practitioners, and organizations willing to publish inspectable results.
 
-However, to maintain the integrity of this data, we enforce strict standards.
+Before contributing, read:
 
----
+1. [`README.md`](README.md) — repository scope and claim boundaries.
+2. [`evidence/README.md`](evidence/README.md) — evidence taxonomy.
+3. [`evidence/SOURCES.md`](evidence/SOURCES.md) — canonical source registry.
+4. [`AGENTS.md`](AGENTS.md) — end-to-end workflow for sources, report changes, and protocol updates.
 
-## 🚫 The "No Vibe Coding" Standard
+## Contribution principles
 
-We are fighting against the flood of unverified, AI-generated noise. Therefore, we cannot become what we fight.
+### Evidence before rhetoric
 
-**1. No Raw AI Output**
-Do not copy-paste output from ChatGPT, Claude, or Gemini directly into this repository.
-*   If you use AI to draft a section, you must **rewrite it** to ensure factual accuracy and human tone.
-*   PRs that smell like "LLM Slop" (repetitive phrasing, hallucinations, lack of specific insight) will be closed without debate.
+Do not submit unsupported claims, promotional language, or criticism based only on intuition.
 
-**2. Data > Vibes**
-We prioritize empirical evidence over subjective feelings.
-*   ❌ **Bad:** "Copilot makes my team lazy."
-*   ✅ **Good:** "After adopting Copilot, our PR rejection rate increased by 15% (Source: Internal Jira Data)."
+Good contributions distinguish:
 
-**3. Anonymity is Key**
-When submitting case studies or "Horror Stories," **sanitize everything**.
-*   Remove company names.
-*   Remove proprietary code.
-*   Focus on the *pattern of failure*, not the specific IP.
+- what was directly observed;
+- what was derived or modeled;
+- what the source author concluded;
+- what this repository infers;
+- what remains unknown.
 
----
+### AI assistance is allowed; unverified output is not
 
-## 📋 How You Can Help
+AI tools may be used for search support, outlining, editing, or drafting. The contributor remains responsible for every claim, citation, and link.
 
-### 1. Submit a "Horror Story" (Case Study)
-We are collecting anonymized examples of **"Plausible Lies"**—code that looked correct, passed tests, but caused architectural rot or production failures.
-*   **Action:** Open an Issue with the tag `case-study`.
-*   **Format:**
-    *   *The Context:* (e.g., React Frontend, Fintech)
-    *   *The AI Mistake:* (e.g., Hallucinated a secure library that didn't exist)
-    *   *The Cost:* (e.g., 3 days of debugging by a Senior Dev)
+Do not submit text that has not been checked against the cited source. Remove fabricated citations, generic filler, unsupported certainty, and repetitive model-generated phrasing.
 
-### 2. Refine the Protocols
-Our [Defense Protocols](protocols/README.md) are battle-tested, but they can be improved.
-*   Do you have a better metric than "Code Churn"?
-*   Do you have a script that detects "AI Slop" in PRs?
-*   **Action:** Submit a Pull Request (PR) to the `protocols/` directory.
+### Preserve mixed and contradictory evidence
 
-### 3. Fix the Report
-If you find factual errors or have newer data (e.g., updated METR/DORA reports):
-*   **Action:** Submit a PR to the relevant chapter in `report/`.
-*   **Requirement:** Cite your sources.
+A source does not need to support the Subprime Code Crisis thesis to be included. Positive productivity evidence, null results, critiques, and replications are necessary for a credible synthesis.
 
----
+### Protect confidential information
 
-## ⚖️ License & Attribution
+For internal case studies:
 
-By contributing to this repository, you agree that your contributions will be licensed under the **CC-BY-SA 4.0** license.
+- remove company and client identifiers unless publication is authorized;
+- remove proprietary code and data;
+- disclose the measurement window and relevant context;
+- explain how metrics were calculated;
+- avoid presenting one team as representative of the industry.
 
-You also agree to the **Code of Conduct**:
-*   Critique the *tool* and the *process*, not the *person*.
-*   Many developers are forced to use these tools by management. They are victims of the crisis, not the villains.
+## Ways to contribute
 
----
+### Add or update a source
 
-**Read. Verify. Push Back.**
+Follow the source lifecycle in [`AGENTS.md`](AGENTS.md):
+
+1. register the source in `evidence/SOURCES.md`;
+2. classify it;
+3. create an evidence brief;
+4. update the evidence-class index;
+5. integrate it into the report only where relevant;
+6. reassess README-level claims and protocols;
+7. update `REFERENCES.md` last.
+
+Do not add a citation directly to the report without registering it.
+
+### Submit a measured case study
+
+Open an issue or PR with:
+
+- context and system boundary;
+- adoption intervention;
+- observation period;
+- comparator or baseline;
+- metric definitions;
+- measured results;
+- confounders and limitations;
+- operational response;
+- disclosure and anonymization status.
+
+Anecdotes may be useful for hypothesis generation, but must be labeled as anecdotes rather than empirical proof.
+
+### Improve the report
+
+Report changes should:
+
+- link to reviewed evidence briefs where possible;
+- distinguish evidence-backed findings from systems inference and warning scenarios;
+- weaken or remove claims when the evidence does not support them;
+- update the claim-confidence map when a major conclusion changes.
+
+### Improve the protocols
+
+Protocol changes should explain:
+
+- the operational problem;
+- the control or decision rule;
+- the intended scope;
+- required evidence or signals;
+- failure modes;
+- conditions for escalation, pause, or reversal;
+- whether the change is evidence-backed, systems-derived, or a proposed practice.
+
+Protocols are adaptable operating patterns, not universal thresholds.
+
+## Pull-request expectations
+
+A PR should state:
+
+- files changed and why;
+- source IDs affected;
+- claims added, removed, or reclassified;
+- evidence boundaries;
+- what the cited sources do not establish;
+- whether README claims or protocols were reassessed;
+- any unresolved source-quality or link issues.
+
+For substantial new evidence, prefer separate PRs for:
+
+1. registration and evidence brief;
+2. report integration;
+3. repository-map or protocol changes, only when required.
+
+## License and conduct
+
+By contributing, you agree that your contribution will be licensed under **CC BY-SA 4.0**, unless a specific repository file states otherwise.
+
+Critique claims, tools, methods, incentives, and operating models—not individuals. Disclose commercial or institutional conflicts when they may affect interpretation.

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,53 +1,117 @@
----
+# Bibliography and Data Sources
 
-# 📚 Bibliography & Data Sources
+> **Navigation:** [Home](README.md) | [Evidence Library](evidence/README.md) | [Source Registry](evidence/SOURCES.md) | [Read the Report](report/01_the_illusion.md)
 
-> **Navigation:** [🏠 Home](README.md) | [📉 Read the Report](report/01_the_illusion.md)
+This file is the compact human-readable bibliography for the repository.
 
-This repository relies on empirical data, not marketing hype. Below is the complete list of primary research, industry reports, and theoretical frameworks cited in the **Subprime Code Crisis** analysis.
+The canonical classification, review status, and report usage for each source live in [`evidence/SOURCES.md`](evidence/SOURCES.md). Detailed source evaluation lives in evidence briefs under `evidence/`.
 
-## 🧪 Primary Research (The Data)
+A source appearing here is not automatically peer reviewed, independently validated, or strong enough to support every claim attributed to it. Follow the source-registry and evidence-brief links for boundaries and limitations.
 
-**NBER — Software Production Hierarchy**
-*   **Demirer, Musolff & Yang (NBER Working Paper, 2026):** ["Writing Code vs. Shipping Code: Productivity Effects Across Generations of AI Coding Tools"](https://www.nber.org/papers/w35275)
-    *   *Key Finding:* AI coding tools substantially increase commits, but the measured effect attenuates across the production hierarchy. For the cumulative async-agent generation, the reported increase falls from approximately **180% for commits** to **50% for projects** and **30% for releases**; the authors report no increase in total early usage across four app marketplaces.
-    *   *Evidence brief:* [Methods, findings, model-calibrated results, and limitations](evidence/primary/2026-writing-code-vs-shipping-code.md)
-    *   *Status:* NBER working paper; not peer reviewed.
+## Primary empirical research
 
-**METR (Model Evaluation & Threat Research)**
-*   [Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/) (July 2025)
-    *   *Key Finding:* Experienced developers were **19% slower** when using AI, despite feeling 20% faster.
-*   [Measuring AI Ability to Complete Long Tasks](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/) (March 2025)
-    *   *Key Finding:* AI agents have a **50% failure rate** on tasks requiring ~7 hours of human effort.
+### P-2026-01 — Writing Code vs. Shipping Code
 
-**Academic & Large Scale Studies**
-*   **Xu et al. (arXiv, 2025):** ["AI-Assisted Programming Decreases the Productivity of Experienced Developers"](https://arxiv.org/abs/2510.10165)
-    *   *Key Finding:* Analysis of 10,000+ developers. Seniors saw **-19% coding output** and **+6.5% review load**. Peripheral contributors increased output by +43.5%.
-*   **Agarwal et al. (arXiv, 2026):** ["AI IDEs or Autonomous Agents? Measuring the Impact of Coding Agents"](https://arxiv.org/abs/2601.13597)
-    *   *Key Finding:* AI-generated code contains **+18% static analysis warnings** and **+39% higher cognitive complexity** compared to human code.
-*   **Peng et al. (arXiv, 2023):** ["The Impact of AI on Developer Productivity"](https://arxiv.org/abs/2302.06590)
-    *   *Key Finding:* 55.8% speedup on greenfield tasks for less-experienced developers (foundational positive evidence).
+- Demirer, Musolff & Yang. [*Writing Code vs. Shipping Code: Productivity Effects Across Generations of AI Coding Tools*](https://www.nber.org/papers/w35275). NBER Working Paper 35275, 2026.
+- Status: working paper; not peer reviewed.
+- [Reviewed evidence brief](evidence/primary/2026-writing-code-vs-shipping-code.md).
 
-**GitClear**
-*   [AI Assistant Code Quality 2025 Research](https://www.gitclear.com/ai_assistant_code_quality_2025_research) (2025)
-    *   *Key Finding:* Code churn is up, reuse is down (<10%), and copy/pasted code has increased by ~10x.
-*   [How much more productive are AI-powered developers?](https://www.gitclear.com/research/ai_tool_impact_on_developer_productive_output_from_2022_to_2025) (2022-2025)
-    *   *Key Finding:* Net productivity gain is only **~10%** when accounting for rework.
+### P-2025-01 — Experienced open-source developer productivity
 
-## 🏢 Industry Analysis & Financials
+- METR. [*Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity*](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/). July 2025.
+- Status: original research report; detailed repository brief pending.
 
-**Infrastructure & Economics**
-*   **Google Software Engineering (O'Reilly):** [Software Engineering at Google](https://abseil.io/resources/swe-book) — Documentation of the multi-billion dollar infrastructure (Blaze, TAP, Critique) required to support high-velocity engineering.
-*   **Big Tech CapEx (2024-2025):** Data from Alphabet, Meta, and Microsoft 10-K filings showing >$300B combined investment in AI infrastructure.
-*   **The Inference Cost Paradox:** [Generative AI Spending Surged 320%](https://www.arturmarkus.com/the-inference-cost-paradox-why-generative-ai-spending-surged-320-in-2025-despite-per-token-costs-dropping-1000x-and-what-it-means-for-your-ai-budget-in-2026/) — Jevons Paradox: per-token costs dropped 1000x, but total enterprise spend tripled.
+### P-2025-02 — Long-task capability measurement
 
-**Market Sentiment**
-*   **McKinsey & Company:** [2025 AI Report: 88% Adoption, 6% Impact](https://www.banandre.com/blog/mckinsey-2025-ai-report-widespread-adoption-limited-impact)
-*   **Deloitte:** [State of Generative AI in the Enterprise (Q3 2025)](https://www2.deloitte.com/us/en/pages/consulting/articles/state-of-generative-ai-in-enterprise.html)
-*   **Andreas Horn (IBM):** ["The most important chart in AI" (Vertical Curves)](https://www.linkedin.com/posts/andreashorn1_𝗧𝗵𝗲-𝗺𝗼𝘀𝘁-𝗶𝗺𝗽𝗼𝗿𝘁𝗮𝗻𝘁-𝗰𝗵𝗮𝗿𝘁-activity-7425435461994635264-IW2S/)
+- METR. [*Measuring AI Ability to Complete Long Tasks*](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/). March 2025.
+- Status: original measurement report; detailed repository brief pending.
 
-## 📐 Theory & Methodology
+### P-2025-03 — Large-scale developer study
 
-*   **Eliyahu Goldratt (1984):** *The Goal: A Process of Ongoing Improvement* — Foundational text on the Theory of Constraints (optimizing non-bottlenecks creates inventory).
-*   **Software Engineering Insights:** [AI Code Review Paradox](https://www.softwareseni.com/why-ai-coding-speed-gains-disappear-in-code-reviews/)
-*   **TechnoDiaries:** [Post-Copilot Burnout: Are AI Assistants Making Senior Developers the New Bottleneck?](https://technodiaries.medium.com/post-copilot-burnout-are-ai-assistants-making-senior-developers-the-new-bottleneck-1689e20364f1)
+- Xu et al. [*AI-Assisted Programming Decreases the Productivity of Experienced Developers*](https://arxiv.org/abs/2510.10165). arXiv, 2025.
+- Status: preprint; detailed repository brief pending.
+
+### P-2026-02 — AI IDEs and autonomous agents
+
+- Agarwal et al. [*AI IDEs or Autonomous Agents? Measuring the Impact of Coding Agents*](https://arxiv.org/abs/2601.13597). arXiv, 2026.
+- Status: preprint; detailed repository brief pending.
+
+### P-2023-01 — Copilot productivity experiment
+
+- Peng et al. [*The Impact of AI on Developer Productivity: Evidence from GitHub Copilot*](https://arxiv.org/abs/2302.06590). arXiv, 2023.
+- Status: preprint; detailed repository brief pending.
+
+### P-2025-04 — GitClear code-change research
+
+- GitClear. [*AI Assistant Code Quality 2025 Research*](https://www.gitclear.com/ai_assistant_code_quality_2025_research). 2025.
+- Status: original commercial measurement report; methodology and conflict-of-interest brief pending.
+
+### P-2025-05 — GitClear productivity research
+
+- GitClear. [*How Much More Productive Are AI-Powered Developers?*](https://www.gitclear.com/research/ai_tool_impact_on_developer_productive_output_from_2022_to_2025). 2022–2025 study period.
+- Status: original commercial measurement report; methodology and conflict-of-interest brief pending.
+
+## Primary documentary sources
+
+### D-2019-01 — Google engineering-system documentation
+
+- Winters, Manshreck & Wright, eds. [*Software Engineering at Google*](https://abseil.io/resources/swe-book). O'Reilly / Google, 2019.
+- Status: first-party engineering documentation; documentary brief pending.
+
+### D-2024-01 to D-2024-03 — Company filings
+
+- Alphabet annual and regulatory filings.
+- Meta annual and regulatory filings.
+- Microsoft annual and regulatory filings.
+- Status: first-party documentary sources. Exact filing versions and claim mappings must be recorded in documentary briefs before aggregate spending figures are treated as load-bearing.
+
+## Secondary evidence and industry context
+
+### S-2025-01 — Deloitte enterprise survey
+
+- Deloitte. [*State of Generative AI in the Enterprise*](https://www2.deloitte.com/us/en/pages/consulting/articles/state-of-generative-ai-in-enterprise.html). Q3 2025 edition cited by the report.
+- Status: industry survey and analysis; brief pending.
+
+### S-2025-02 — McKinsey adoption and impact reporting
+
+- Current repository link: [third-party summary of a McKinsey 2025 report](https://www.banandre.com/blog/mckinsey-2025-ai-report-widespread-adoption-limited-impact).
+- Status: secondary link only. Replace with and review the original McKinsey publication before using the figures as load-bearing evidence.
+
+### S-2025-03 — Inference-cost commentary
+
+- Artur Markus. [*The Inference Cost Paradox*](https://www.arturmarkus.com/the-inference-cost-paradox-why-generative-ai-spending-surged-320-in-2025-despite-per-token-costs-dropping-1000x-and-what-it-means-for-your-ai-budget-in-2026/).
+- Status: practitioner analysis; brief pending.
+
+### S-2026-01 — Capability-curve commentary
+
+- Andreas Horn. [*The Most Important Chart in AI*](https://www.linkedin.com/posts/andreashorn1_𝗧𝗵𝗲-𝗺𝗼𝘀𝘁-𝗶𝗺𝗽𝗼𝗿𝘁𝗮𝗻𝘁-𝗰𝗵𝗮𝗿𝘁-activity-7425435461994635264-IW2S/).
+- Status: practitioner commentary; use for framing, not primary empirical support.
+
+### S-2025-04 — Code-review bottleneck synthesis
+
+- SoftwareSeni. [*Why AI Coding Speed Gains Disappear in Code Reviews*](https://www.softwareseni.com/why-ai-coding-speed-gains-disappear-in-code-reviews/).
+- Status: practitioner synthesis; brief pending.
+
+### S-2025-05 — Senior-developer bottleneck commentary
+
+- TechnoDiaries. [*Post-Copilot Burnout: Are AI Assistants Making Senior Developers the New Bottleneck?*](https://technodiaries.medium.com/post-copilot-burnout-are-ai-assistants-making-senior-developers-the-new-bottleneck-1689e20364f1).
+- Status: practitioner reporting; use for context and hypothesis generation.
+
+## Theory and methodology
+
+### M-1984-01 — Theory of Constraints
+
+- Goldratt, Eliyahu M. *The Goal: A Process of Ongoing Improvement*. 1984.
+- Status: methodology source used to interpret bottleneck migration, local optimization, and inventory. It is not direct evidence of AI-tool effects.
+
+## Maintenance rule
+
+When adding or updating a source:
+
+1. register it in `evidence/SOURCES.md`;
+2. classify it and create or update an evidence brief;
+3. integrate it into the report only where it changes the argument;
+4. reassess README-level claims and protocols;
+5. update this bibliography last.
+
+See [`AGENTS.md`](AGENTS.md) for the complete workflow.

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -1,54 +1,102 @@
 # Evidence Library
 
-This directory separates empirical sources from the report's interpretation and from the repository's operational protocols.
+This directory separates external evidence from the report's interpretation and from the repository's operational protocols.
 
-The goal is not to flatten every source into a single confidence level. Different materials answer different questions and support different kinds of claims.
+The goal is not to flatten every source into one confidence score. Different source types answer different questions and support different claims.
+
+## Start here
+
+- [`SOURCES.md`](SOURCES.md) — canonical registry of all external sources, classifications, review status, and report usage.
+- [`../REFERENCES.md`](../REFERENCES.md) — compact human-readable bibliography derived from the registry.
+- [`../AGENTS.md`](../AGENTS.md) — workflow for reading the repository and adding or updating evidence.
 
 ## Evidence classes
 
 ### [Primary empirical research](primary/README.md)
-Original studies, working papers, controlled experiments, and large-scale observational analyses that directly report methods and results.
 
-Use these sources for claims about measured effects. Record the publication status, dataset, method, directly observed findings, model-derived estimates, and limitations.
+Original studies, working papers, controlled experiments, large-scale observational analyses, and original measurement reports with inspectable methods.
+
+Use these sources for claims about measured effects. Record publication status, dataset, method, directly observed findings, model-derived estimates, and limitations.
+
+### [Primary documentary sources](documentary/README.md)
+
+First-party records such as filings, official documentation, standards, policies, and published engineering-system descriptions.
+
+Use these sources for factual claims about what an organization reported, documented, spent, implemented, or required. Documentary evidence does not automatically establish independent validation or causal effect.
 
 ### [Secondary evidence](secondary/README.md)
-Industry reports, practitioner analyses, replications, reviews, and other materials that synthesize or interpret primary data.
 
-Use these sources for triangulation and context, not as substitutes for the underlying study when the primary source is available.
+Industry reports, practitioner analyses, reviews, replications, critiques, and materials that synthesize or interpret primary evidence.
+
+Use these sources for triangulation, context, and hypothesis generation. Do not substitute them for an available primary source.
+
+### [Theory and methodology](methodology/README.md)
+
+Frameworks used to interpret delivery-system behavior, such as Theory of Constraints, productivity models, queueing, reliability, and control concepts.
+
+These sources support analytical reasoning. They are not direct empirical evidence of AI effects unless they include an empirical study.
 
 ### [Datasets](datasets/README.md)
+
 Public or documented datasets used by cited research or maintained for independent analysis.
 
-Dataset entries should describe provenance, coverage, known transformations, access conditions, and the claims the data can and cannot support.
+Dataset entries should describe provenance, coverage, transformations, access conditions, licensing, and the claims the data can and cannot support.
 
 ## Relationship to the rest of the repository
 
+- `evidence/SOURCES.md` is the canonical source registry.
+- evidence subdirectories contain reviewed source briefs and class-specific indexes.
+- `REFERENCES.md` is the compact bibliography and navigation view.
 - `report/` contains the Subprime Code Crisis argument and synthesis.
 - `protocols/` contains operational responses and decision rules.
-- `evidence/` contains source-oriented briefs that distinguish reported findings from repository interpretation.
-- `REFERENCES.md` remains the compact bibliography and navigation index.
+- `README.md` contains the repository-level claim-confidence and evidence maps.
+
+A bibliography entry is not an evidence brief. A registered source is not necessarily reviewed. A protocol is not empirical proof.
 
 ## Evidence brief standard
 
 Each evidence brief should include:
 
-1. Full citation and source links.
-2. Publication status, including whether the work is peer reviewed.
-3. Research question and scope.
-4. Dataset and methodology.
-5. Directly observed findings.
-6. Model-calibrated or derived findings.
-7. Interpretation relevant to this repository.
-8. What the source does not establish.
-9. Limitations and external-validity risks.
-10. Links to any local source copy retained in the repository.
+1. Stable source ID from `SOURCES.md`.
+2. Full citation and canonical source links.
+3. Publication status, including whether the work is peer reviewed.
+4. Research question, documentary purpose, or methodological role.
+5. Scope, dataset, and methodology where applicable.
+6. Directly observed or documented findings.
+7. Model-calibrated or derived findings.
+8. Source-author interpretation where material.
+9. Repository interpretation relevant to this project.
+10. What the source does not establish.
+11. Limitations, conflicts of interest, and external-validity risks.
+12. Links to report sections using the source.
+13. Links to any lawful local source copy retained in the repository.
+
+A source may be registered before a full brief exists, but it must be marked **Registered; brief pending**. Pending sources should not carry load-bearing strong claims without visible qualification.
 
 ## Interpretation labels
 
 Use these labels where useful:
 
-- **Observed:** directly reported from the study's empirical analysis.
-- **Derived:** calculated from reported results without adding a new causal claim.
+- **Observed:** directly reported from empirical analysis.
+- **Documented:** explicitly stated in a first-party record.
+- **Derived:** calculated from reported results without introducing a new causal claim.
 - **Model-calibrated:** produced by a fitted or calibrated model rather than directly measured.
-- **Repository interpretation:** the Subprime Code Crisis project's synthesis or application of the evidence.
-- **Not established:** a plausible claim that the source does not itself demonstrate.
+- **Source interpretation:** the source author's explanation or framing.
+- **Repository interpretation:** the Subprime Code Crisis project's synthesis or application.
+- **Not established:** a plausible claim that the source does not demonstrate.
+
+## Source lifecycle
+
+```mermaid
+flowchart LR
+    A[Discover source] --> B[Register in SOURCES.md]
+    B --> C[Classify source]
+    C --> D[Create evidence brief]
+    D --> E[Update class index]
+    E --> F[Integrate into report]
+    F --> G[Reassess README claims]
+    G --> H[Reassess protocols if decisions change]
+    H --> I[Update REFERENCES.md and navigation]
+```
+
+Detailed execution rules are in [`AGENTS.md`](../AGENTS.md).

--- a/evidence/SOURCES.md
+++ b/evidence/SOURCES.md
@@ -1,0 +1,64 @@
+# Source Registry
+
+This file is the canonical registry for external material used by the repository.
+
+`REFERENCES.md` is the compact human-readable bibliography. Evidence subdirectories contain reviewed briefs. This registry records classification and review status for every source, including sources whose briefs are still pending.
+
+## Status values
+
+- **Reviewed brief** — a source-oriented brief exists and has been integrated with explicit limitations.
+- **Registered; brief pending** — the source is used or proposed, but the full evidence brief has not yet been completed.
+- **Documentary entry** — the source supports a factual record rather than an empirical effect estimate.
+- **Methodology entry** — the source provides an interpretive framework rather than direct evidence of AI effects.
+
+## Primary empirical research
+
+| ID | Source | Status | Can support | Current use |
+| --- | --- | --- | --- | --- |
+| **P-2026-01** | Demirer, Musolff & Yang, *Writing Code vs. Shipping Code: Productivity Effects Across Generations of AI Coding Tools*, NBER Working Paper 35275 | [Reviewed brief](primary/2026-writing-code-vs-shipping-code.md) | Measured attenuation from coding activity toward projects, releases, and early marketplace use within the studied setting | `report/01_the_illusion.md`; `report/02_broken_mechanics.md` |
+| **P-2025-01** | METR, *Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity* | Registered; brief pending | Randomized evidence about experienced developers completing familiar open-source tasks with early-2025 tools | Report claims about experienced-developer task completion |
+| **P-2025-02** | METR, *Measuring AI Ability to Complete Long Tasks* | Registered; brief pending | Agent task-completion performance as task duration increases under the study's benchmark design | Agent capability and task-horizon discussion |
+| **P-2025-03** | Xu et al., *AI-Assisted Programming Decreases the Productivity of Experienced Developers* | Registered; brief pending | Large-scale developer-output and review-load associations reported by the authors | Senior-load and productivity discussion |
+| **P-2026-02** | Agarwal et al., *AI IDEs or Autonomous Agents? Measuring the Impact of Coding Agents* | Registered; brief pending | Reported static-analysis and code-structure differences in the study sample | Complexity and quality-risk discussion |
+| **P-2023-01** | Peng et al., *The Impact of AI on Developer Productivity* | Registered; brief pending | Controlled evidence of task-completion acceleration in a bounded greenfield task | Positive productivity evidence and boundary conditions |
+| **P-2025-04** | GitClear, *AI Assistant Code Quality 2025 Research* | Registered; brief pending | Original commercial measurement of code-change patterns, subject to methodology and conflict review | Churn, duplication, and reuse discussion |
+| **P-2025-05** | GitClear, *How Much More Productive Are AI-Powered Developers?* | Registered; brief pending | Original commercial productivity measurement, subject to methodology and conflict review | Net-output and rework discussion |
+
+## Primary documentary sources
+
+| ID | Source | Status | Can support | Current use |
+| --- | --- | --- | --- | --- |
+| **D-2019-01** | *Software Engineering at Google* and associated first-party engineering documentation | Documentary entry; brief pending | Descriptions of Google's engineering infrastructure and practices | Infrastructure and verification-capacity discussion |
+| **D-2024-01** | Alphabet annual filings | Documentary entry; brief pending | Alphabet-reported capital expenditure and business records | AI infrastructure-spending discussion |
+| **D-2024-02** | Meta annual filings | Documentary entry; brief pending | Meta-reported capital expenditure and business records | AI infrastructure-spending discussion |
+| **D-2024-03** | Microsoft annual filings | Documentary entry; brief pending | Microsoft-reported capital expenditure and business records | AI infrastructure-spending discussion |
+
+## Secondary evidence and industry context
+
+| ID | Source | Status | Can support | Current use |
+| --- | --- | --- | --- | --- |
+| **S-2025-01** | Deloitte, *State of Generative AI in the Enterprise* | Registered; brief pending | Surveyed enterprise adoption, expectations, and reported constraints | Adoption and organizational-context discussion |
+| **S-2025-02** | McKinsey enterprise AI reporting, currently linked through a third-party summary | Registered; replacement primary link required | Context on reported adoption and impact; not load-bearing until the original report is linked and reviewed | Market-sentiment discussion |
+| **S-2025-03** | Artur Markus, *The Inference Cost Paradox* | Registered; brief pending | Practitioner interpretation of enterprise AI spending and Jevons-style effects | Cost-paradox discussion |
+| **S-2026-01** | Andreas Horn, *The Most Important Chart in AI* | Registered; brief pending | Practitioner framing and visual interpretation | Market and capability narrative context |
+| **S-2025-04** | SoftwareSeni, *Why AI Coding Speed Gains Disappear in Code Reviews* | Registered; brief pending | Practitioner synthesis about review bottlenecks | Review-bottleneck framing |
+| **S-2025-05** | TechnoDiaries, *Post-Copilot Burnout* | Registered; brief pending | Practitioner reporting and hypothesis generation | Senior-bottleneck and burnout context |
+
+## Theory and methodology
+
+| ID | Source | Status | Can support | Current use |
+| --- | --- | --- | --- | --- |
+| **M-1984-01** | Eliyahu M. Goldratt, *The Goal: A Process of Ongoing Improvement* | Methodology entry; brief pending | Theory of Constraints concepts such as bottlenecks, inventory, and local optimization | Delivery-system interpretation throughout the report |
+
+## Datasets
+
+Dataset-level entries should be added to `datasets/README.md` when the repository independently uses, republishes, or analyzes a dataset. Datasets merely described inside an evidence brief do not need a separate registry entry unless they become reusable repository assets.
+
+## Registry maintenance rules
+
+1. Register a source before adding it to the report.
+2. Do not mark a source `Reviewed brief` until a source-oriented brief exists.
+3. A pending brief may support provisional or low-load claims, but strong claims should link to a reviewed brief.
+4. Replace secondary links with original sources whenever possible.
+5. When publication status or source content changes, update this registry, the brief, report usage, and `REFERENCES.md` together.
+6. Preserve contradictory and negative evidence; classification is independent of whether a source supports the repository thesis.

--- a/evidence/documentary/README.md
+++ b/evidence/documentary/README.md
@@ -1,0 +1,30 @@
+# Primary Documentary Sources
+
+This directory contains source-oriented briefs for first-party records that establish what an organization officially reported, documented, or required.
+
+Examples include:
+
+- annual reports and regulatory filings;
+- official engineering documentation;
+- standards and specifications;
+- product documentation;
+- policy documents;
+- organizational records and published system descriptions.
+
+Documentary sources can support factual claims about spending, systems, policies, or published practices. They do not automatically establish causal effects or independent validation.
+
+Each brief should include:
+
+1. source ID and full citation;
+2. issuing organization and publication date;
+3. documentary purpose and scope;
+4. relevant reported facts;
+5. definitions and accounting boundaries;
+6. repository interpretation;
+7. what the document does not establish;
+8. limitations, incentives, and version history;
+9. report locations using the source.
+
+## Current status
+
+The documentary sources currently used by the repository are registered in [`../SOURCES.md`](../SOURCES.md). Detailed briefs are pending.

--- a/evidence/methodology/README.md
+++ b/evidence/methodology/README.md
@@ -1,0 +1,29 @@
+# Theory and Methodology
+
+This directory contains briefs for frameworks used to interpret evidence and reason about software-delivery systems.
+
+Examples include:
+
+- Theory of Constraints;
+- software-engineering productivity models;
+- reliability and control theory;
+- queueing and flow models;
+- organizational and economic frameworks.
+
+Methodology sources do not directly measure the effect of AI coding tools unless they also contain an empirical study. They support the repository's analytical method, vocabulary, and system-level inferences.
+
+Each brief should include:
+
+1. source ID and full citation;
+2. framework purpose and original domain;
+3. core concepts used by this repository;
+4. how the framework is applied to software delivery;
+5. assumptions required for the application;
+6. repository interpretation;
+7. what the framework does not empirically establish;
+8. competing frameworks or known critiques;
+9. report locations using the framework.
+
+## Current status
+
+The methodology sources currently used by the repository are registered in [`../SOURCES.md`](../SOURCES.md). Detailed briefs are pending.


### PR DESCRIPTION
## Summary

Completes a repository-wide evidence-governance consistency pass after the report, evidence-map, and protocol rewrites.

The main problem was structural: `REFERENCES.md` acted as both bibliography and partial evidence database, while `evidence/` contained a taxonomy but only one reviewed brief. The README also described documentary and methodology source classes that did not exist as directories.

This PR separates those responsibilities and adds an explicit workflow for human contributors and AI agents.

## Changes

### Canonical source registry

Adds `evidence/SOURCES.md` as the canonical inventory for every external source, including:

- stable source IDs;
- evidence classification;
- review status;
- what each source can support;
- current report usage;
- explicit `brief pending` status for sources not yet fully reviewed.

The existing bibliography has been migrated into this registry and classified as:

- primary empirical research;
- primary documentary sources;
- secondary evidence and industry context;
- theory and methodology;
- datasets.

### Evidence taxonomy alignment

Adds missing evidence classes:

- `evidence/documentary/README.md`;
- `evidence/methodology/README.md`.

Updates `evidence/README.md` so the filesystem now matches the evidence map already described in the main README.

### References role clarified

Reworks `REFERENCES.md` into a compact bibliography view derived from the canonical registry.

It now:

- preserves source links;
- includes source IDs and publication status;
- links to reviewed briefs;
- clearly marks pending briefs;
- flags the McKinsey entry as a third-party summary requiring replacement with the original source;
- avoids presenting short key-finding summaries as a substitute for evidence review.

### Agent and contributor workflow

Adds root-level `AGENTS.md` with:

- repository reading order;
- evidence/report/protocol boundaries;
- source ID conventions;
- exact source-addition lifecycle;
- rules for updating working papers and revised sources;
- evidence-strength rules;
- PR checklist;
- guidance on when README and protocols should or should not change.

Rewrites `CONTRIBUTING.md` to match that workflow and removes the remaining campaign-style and anti-AI rhetoric.

## Files changed

- `AGENTS.md` — new
- `evidence/SOURCES.md` — new canonical source registry
- `evidence/documentary/README.md` — new
- `evidence/methodology/README.md` — new
- `evidence/README.md` — updated taxonomy and lifecycle
- `REFERENCES.md` — converted to compact bibliography
- `CONTRIBUTING.md` — aligned contribution workflow

## Important design decision

This PR does **not** pretend that every legacy reference already has a reviewed evidence brief.

Only the NBER source currently has one. All other sources are migrated into the canonical registry and explicitly marked as pending. This is more honest than generating shallow or unverified briefs in bulk.

## Follow-up backlog identified by the audit

After this PR, the next evidence work should be source-by-source rather than another structural rewrite:

1. METR experienced-developer study;
2. Peng et al. positive productivity experiment;
3. Xu et al.;
4. Agarwal et al.;
5. GitClear reports with commercial-methodology review;
6. exact Alphabet, Meta, and Microsoft filing versions;
7. replacement of the third-party McKinsey link with the original report;
8. review of exact numeric claims in the README Crisis Map and report chapters against those briefs.

## Review focus

1. Is `evidence/SOURCES.md` the right canonical source of truth?
2. Are documentary and methodology sources now separated correctly from empirical evidence?
3. Is it clear that `REFERENCES.md` is a bibliography rather than an evidence database?
4. Is the agent workflow strict enough to prevent direct citation insertion without classification and review?
5. Are pending briefs labeled honestly enough to avoid false confidence?