### PR TITLE
Track source review and integration verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,13 +170,159 @@ After the source is registered and integrated:
 - verify links from report sections;
 - verify navigation in any changed files.
 
+## Verifying the integration of each source
+
+Creating an evidence brief does not complete the source work. Every reviewed source must pass a repository-wide integration verification before it is considered fully processed.
+
+Apply this procedure both to newly added sources and to legacy sources already cited in the repository.
+
+### 1. Establish the source ground truth
+
+Read the original source rather than relying on the current report text or an existing summary. Record:
+
+- canonical title, authors, date, and publication status;
+- official publisher or author URL;
+- research design, dataset, population, time period, and comparator;
+- exact definitions of the reported metrics;
+- exact reported numbers and uncertainty where available;
+- whether each result is observed, derived, model-calibrated, self-reported, or interpreted by the source authors;
+- stated limitations, conflicts of interest, and external-validity boundaries.
+
+### 2. Locate every repository use
+
+Search the whole repository for:
+
+- source ID;
+- author names;
+- publication title;
+- distinctive metric names;
+- every numeric value attributed to the source;
+- paraphrases of its findings that may not contain a citation.
+
+Inspect at minimum:
+
+- all files under `report/`;
+- `README.md`, including diagrams, tables, captions, the executive summary, and the claim-confidence map;
+- all files under `protocols/`;
+- `REFERENCES.md`;
+- `evidence/SOURCES.md` and the relevant evidence indexes.
+
+Do not rely only on the `Current use` field in `evidence/SOURCES.md`; verify actual repository usage.
+
+### 3. Build a claim-to-source trace
+
+For every repository statement supported by the source, record the relationship:
+
+| Repository claim | Location | Source result | Relationship | Action |
+| --- | --- | --- | --- | --- |
+| Exact or paraphrased statement | File and section | Exact finding or record | Direct, derived, synthesis, scenario, or unsupported | Keep, qualify, correct, relocate, or remove |
+
+The trace may be included in the evidence brief, PR description, or review notes. It must be inspectable during review.
+
+### 4. Verify numbers and units
+
+For every number derived from or attributed to the source:
+
+- confirm the numerator, denominator, unit, population, and time window;
+- distinguish percentage changes from percentage-point changes;
+- distinguish cumulative, average, median, long-run, and short-run effects;
+- preserve confidence intervals or uncertainty when they materially affect interpretation;
+- do not combine numbers from different samples, tools, studies, or periods into one apparent sequence without explicit labeling;
+- independently reproduce simple derived calculations where practical;
+- remove obsolete or rounded numbers that cannot be traced to the source.
+
+A number in a diagram or table is a claim and must be verified in the same way as prose.
+
+### 5. Verify argument fit
+
+Check whether the report uses the source for a conclusion its design can actually support.
+
+Ask:
+
+- Does observational evidence get presented as causal?
+- Does a bounded task result get generalized to an organization, industry, or economy?
+- Are experienced developers, junior developers, open-source contributors, and enterprise teams being treated as interchangeable populations?
+- Are activity measures being described as productivity, quality, shipped value, or business impact without justification?
+- Is source-author interpretation being presented as an observed finding?
+- Is repository synthesis clearly identified as synthesis?
+- Does contradictory or positive evidence receive equivalent treatment?
+
+Correct the argument even when the correction weakens the repository thesis.
+
+### 6. Verify report integration
+
+For every report section using the source:
+
+- ensure the source is introduced with enough methodological context;
+- link to the evidence brief rather than only to an external URL;
+- keep directly reported findings separate from repository inference;
+- expose material limitations near the claim, not only in the evidence brief;
+- remove duplicate retellings that drift into inconsistent wording;
+- update neighboring paragraphs when a corrected claim changes the logic of the section;
+- verify that chapter conclusions still follow after the correction.
+
+Do not treat a corrected citation as sufficient when the surrounding argument remains misleading.
+
+### 7. Verify repository-level integration
+
+Reassess `README.md` when the source contributes to:
+
+- the executive summary;
+- the claim-confidence map;
+- the Evidence Map;
+- the Crisis Map or another diagram;
+- repository-level numeric claims;
+- the reading guide or source coverage description.
+
+Multi-source diagrams must label source boundaries. Do not visually connect numbers from unrelated studies as though they describe one observed causal chain.
+
+### 8. Verify protocol implications
+
+Inspect protocols for rules, metrics, thresholds, or explanations that cite or implicitly rely on the source.
+
+Then choose one explicit outcome:
+
+- **No protocol change** — the source changes evidence description but not an operational decision.
+- **Protocol clarification** — wording or evidence boundaries must be corrected.
+- **Protocol change** — a metric, gate, risk boundary, escalation rule, disclosure requirement, or organizational control must change.
+
+Document the decision. Do not update a protocol merely to create symmetry with a report change.
+
+### 9. Synchronize source records
+
+After all corrections:
+
+- update the evidence brief;
+- update the source status and `Current use` locations in `evidence/SOURCES.md`;
+- update the relevant evidence-directory index;
+- update `REFERENCES.md`;
+- verify all internal and external links;
+- record superseded versions, corrections, or removed claims explicitly.
+
+### 10. Declare completion
+
+A source is fully integrated only when all of the following are true:
+
+- [ ] The original source has been read and classified.
+- [ ] A reviewed evidence brief exists.
+- [ ] Every repository mention and attributed number has been located.
+- [ ] Every material number has been checked against the source.
+- [ ] Claim strength matches the research design.
+- [ ] Report arguments and nearby conclusions remain valid after corrections.
+- [ ] README tables and diagrams have been reassessed.
+- [ ] Protocol implications have an explicit documented outcome.
+- [ ] `evidence/SOURCES.md`, evidence indexes, and `REFERENCES.md` are synchronized.
+- [ ] Links work and no obsolete parallel summary remains.
+
+Do not mark a source as fully integrated merely because its evidence brief is complete.
+
 ## Updating an existing source
 
 When a working paper becomes peer reviewed, a report is revised, or a dataset changes:
 
 1. Update `evidence/SOURCES.md`.
 2. Update the evidence brief and clearly note the new version.
-3. Recheck every report claim that uses the source.
+3. Re-run the full **Verifying the integration of each source** procedure.
 4. Reassess claim confidence.
 5. Update `REFERENCES.md`.
 6. Record corrections rather than silently preserving obsolete numbers.
@@ -201,19 +347,22 @@ Before opening a PR, confirm:
 - [ ] Findings and repository interpretation are separated.
 - [ ] Publication status is explicit.
 - [ ] Strong claims link to reviewed briefs where possible.
+- [ ] All repository uses and attributed numbers were searched for.
+- [ ] A claim-to-source trace was created for material uses.
 - [ ] Report language matches the source design.
-- [ ] README claim confidence was reassessed.
-- [ ] Protocol implications were considered but not forced.
-- [ ] `REFERENCES.md` and indexes are synchronized.
+- [ ] Numeric values, units, samples, and time windows were checked.
+- [ ] README claim confidence and diagrams were reassessed.
+- [ ] Protocol implications have an explicit outcome.
+- [ ] `REFERENCES.md`, `evidence/SOURCES.md`, and indexes are synchronized.
 - [ ] Navigation links work.
-- [ ] The PR description lists evidence boundaries and what the source does not establish.
+- [ ] The PR description lists evidence boundaries, corrections, and what the source does not establish.
 
 ## Preferred PR structure
 
 For a substantial new source, use separate PRs when practical:
 
 1. source registration and evidence brief;
-2. report integration;
+2. report integration and source-wide verification;
 3. repository-map or protocol updates, only if needed.
 
-This keeps evidence review separate from argument and policy changes.
+This keeps evidence review separate from argument and policy changes while requiring the complete integration verification before a source is considered finished.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ The repository has four distinct layers:
 1. **Evidence** — what external sources actually report.
 2. **Report** — the Subprime Code Crisis synthesis and argument.
 3. **Protocols** — practical controls derived from the risk analysis.
-4. **Repository maps** — navigation, claim confidence, and source indexes.
+4. **Repository maps** — navigation, claim confidence, source status, and bibliography.
 
 Do not collapse these layers.
 
@@ -17,15 +17,16 @@ Do not collapse these layers.
 
 Before making changes, read in this order:
 
-1. `README.md` — scope, claim-confidence map, evidence map, and repository structure.
+1. `README.md` — scope, major claims, evidence map, and repository structure.
 2. `evidence/README.md` — source taxonomy and evidence-brief standard.
-3. `evidence/SOURCES.md` — canonical source registry and review status.
-4. Relevant evidence brief under `evidence/`.
-5. Relevant chapter under `report/`.
-6. Relevant operational response under `protocols/`.
-7. `CONTRIBUTING.md` — contribution and disclosure requirements.
+3. `evidence/SOURCES.md` — canonical source registry, evidence-review status, integration-audit status, and current use.
+4. The relevant evidence brief under `evidence/`, when one exists.
+5. Every relevant chapter under `report/`.
+6. Every relevant operational response under `protocols/`.
+7. `REFERENCES.md` — compact bibliography.
+8. `CONTRIBUTING.md` — contribution and disclosure requirements.
 
-Use `REFERENCES.md` for human-readable bibliography navigation, not as the canonical source-classification database.
+`REFERENCES.md` is not the canonical status database. `evidence/SOURCES.md` is.
 
 ## Repository boundaries
 
@@ -33,54 +34,94 @@ Use `REFERENCES.md` for human-readable bibliography navigation, not as the canon
 
 Evidence entries describe external material. They must separate:
 
-- directly observed findings;
+- directly observed or documented findings;
 - derived calculations;
 - model-calibrated estimates;
 - source-author interpretation;
 - repository interpretation;
 - claims not established by the source;
-- limitations and external-validity risks.
+- limitations, conflicts, and external-validity risks.
 
 Never write a repository conclusion as though it were a finding reported by a source.
 
 ### Report layer
 
-The report may combine multiple sources and systems reasoning. Every material factual claim should trace to:
+The report may combine multiple sources and systems reasoning. Every material factual claim must trace to:
 
 - a reviewed evidence brief; or
 - a registered source whose brief is explicitly marked pending.
 
-When a source is not strong enough for a causal claim, use bounded language such as `suggests`, `is consistent with`, `may indicate`, or `supports the risk hypothesis`.
+Use bounded language when the design cannot support a strong causal or general claim.
 
 ### Protocol layer
 
-Protocols are operating patterns, not empirical proof. A protocol may be motivated by evidence and systems analysis, but it must not present a local threshold, role, gate, or workflow as universally validated unless a source directly establishes that claim.
+Protocols are operating patterns, not empirical proof. A source may motivate a protocol, but no local threshold, gate, role, workflow, or control is universally validated unless evidence directly supports that claim.
 
 ### Repository maps
 
-`README.md`, `evidence/SOURCES.md`, and `REFERENCES.md` must remain mutually consistent:
+The following must remain synchronized:
 
-- `evidence/SOURCES.md` is the canonical registry;
-- evidence subdirectory indexes list reviewed briefs;
-- `REFERENCES.md` is a compact bibliography generated from the registry;
-- `README.md` summarizes source families and major claims.
+- `evidence/SOURCES.md` — canonical source and status registry;
+- evidence directory indexes — reviewed briefs available in each class;
+- `REFERENCES.md` — compact bibliography;
+- `README.md` — repository-level claims, maps, diagrams, and source coverage.
 
-## Adding a new source
+## Source state model
 
-Use this sequence. Do not skip directly to editing the report.
+Every source has two independent states in `evidence/SOURCES.md`.
+
+### Evidence review
+
+Allowed values:
+
+- `Registered`
+- `Brief in progress`
+- `Reviewed brief`
+- `Needs re-review`
+
+### Integration audit
+
+Allowed values:
+
+- `Not started`
+- `In progress`
+- `Corrections required`
+- `Verified`
+- `Needs re-verification`
+
+A source is fully processed only when:
+
+```text
+Evidence review = Reviewed brief
+Integration audit = Verified
+```
+
+The existence of a brief does not imply that report integration has been verified.
+
+`Last verified` must contain a date only when `Integration audit = Verified`. Otherwise use `—`.
+
+## Mandatory source-processing flow
+
+Use this flow for every new source and every legacy source already used by the repository.
+
+Do not skip steps, and do not mark the source complete after creating the brief.
 
 ### Step 1 — Register the source
 
-Add the source to `evidence/SOURCES.md` with:
+Add the source to `evidence/SOURCES.md` before adding or revising report claims.
+
+Record:
 
 - stable source ID;
-- full title and authors or publishing organization;
+- canonical title and authors or publisher;
 - year and publication status;
 - canonical URL;
 - evidence class;
-- current review status;
-- report locations where it is used or proposed;
-- short note on what it can support.
+- `Evidence review = Registered`;
+- `Integration audit = Not started`;
+- `Last verified = —`;
+- what the source can support;
+- known or proposed repository use.
 
 Use IDs in the form:
 
@@ -90,279 +131,306 @@ Use IDs in the form:
 - `M-YYYY-NN` — methodology or theory;
 - `DS-YYYY-NN` — dataset.
 
-### Step 2 — Classify it
+### Step 2 — Classify the source
 
 Choose exactly one primary class:
 
-- `evidence/primary/` — original empirical research or original measurement with inspectable methods;
-- `evidence/documentary/` — first-party filings, official documentation, standards, and organizational records;
-- `evidence/secondary/` — surveys, reviews, practitioner analysis, critiques, and industry synthesis;
-- `evidence/methodology/` — theories and analytical frameworks used to interpret evidence;
-- `evidence/datasets/` — datasets and data registries.
+- `evidence/primary/`
+- `evidence/documentary/`
+- `evidence/secondary/`
+- `evidence/methodology/`
+- `evidence/datasets/`
 
-Classification describes what the source is, not whether its conclusions are favorable to the repository thesis.
+Classification describes what the source is, not whether it supports the repository thesis.
 
-### Step 3 — Create an evidence brief
+### Step 3 — Start the evidence review
 
-Create a kebab-case Markdown file in the correct evidence directory. Include:
+When review begins, set:
+
+```text
+Evidence review = Brief in progress
+Integration audit = Not started
+Last verified = —
+```
+
+Read the original source, not only a summary or the repository's existing interpretation.
+
+### Step 4 — Create the evidence brief
+
+Create a kebab-case Markdown file in the correct evidence directory.
+
+Include:
 
 1. Source ID and full citation.
-2. Publication status.
+2. Publication status and version.
 3. Research question or documentary purpose.
-4. Scope, dataset, and methodology where applicable.
+4. Scope, dataset, population, time period, comparator, and methodology.
 5. Directly observed or documented findings.
 6. Derived or model-calibrated findings.
-7. Repository-relevant interpretation.
-8. What the source does not establish.
-9. Limitations, conflicts of interest, and external-validity risks.
-10. Links to report sections using the source.
+7. Source-author interpretation.
+8. Repository-relevant interpretation.
+9. What the source does not establish.
+10. Limitations, conflicts, and external-validity risks.
+11. Known repository locations using the source.
+12. A `Repository integration audit` section.
 
-A source may be registered before the brief is complete, but it must be marked `Brief pending` and should not become a load-bearing source for a strong claim.
+Use this section template:
 
-### Step 4 — Update the evidence index
+```markdown
+## Repository integration audit
 
-Add the reviewed brief to the relevant directory `README.md` and change its status in `evidence/SOURCES.md` to `Reviewed brief`.
+- Integration status: Not started | In progress | Corrections required | Verified | Needs re-verification
+- Repository search completed:
+- Report mentions checked:
+- Numeric claims checked:
+- README claims and diagrams checked:
+- Protocol outcome: No change | Clarification | Operational change
+- Corrections made:
+- Current-use locations confirmed:
+- Verification date:
+```
 
-### Step 5 — Integrate it into the report
+When the brief is complete and indexed, set:
 
-Edit only the chapter where the source materially changes the argument.
+```text
+Evidence review = Reviewed brief
+Integration audit = Not started
+Last verified = —
+```
 
-For each integration:
+This is not completion of the source-processing flow.
 
-- state what the source actually measured;
-- separate findings from repository inference;
-- link to the evidence brief;
-- add visible limitations where the finding could be overgeneralized;
-- remove or weaken older claims if the new source contradicts them.
+### Step 5 — Start the integration audit
 
-Do not add a source merely as citation decoration.
+Before changing report text, set:
 
-### Step 6 — Reassess repository-level claims
+```text
+Integration audit = In progress
+Last verified = —
+```
 
-Update `README.md` only when the new source changes:
-
-- the claim-confidence map;
-- the evidence map coverage;
-- the executive summary;
-- a major repository-level conclusion.
-
-Do not update the README for every minor source.
-
-### Step 7 — Reassess protocols
-
-Update protocols only when the evidence changes an operational decision, such as:
-
-- a risk boundary;
-- a metric definition;
-- a gate;
-- an escalation rule;
-- a disclosure requirement;
-- an organizational control.
-
-New evidence does not automatically require a protocol change.
-
-### Step 8 — Update bibliography and navigation
-
-After the source is registered and integrated:
-
-- update `REFERENCES.md`;
-- verify links from the relevant evidence index;
-- verify links from report sections;
-- verify navigation in any changed files.
+Then execute the complete procedure below.
 
 ## Verifying the integration of each source
 
-Creating an evidence brief does not complete the source work. Every reviewed source must pass a repository-wide integration verification before it is considered fully processed.
+### 1. Establish source ground truth
 
-Apply this procedure both to newly added sources and to legacy sources already cited in the repository.
+Record from the original source:
 
-### 1. Establish the source ground truth
-
-Read the original source rather than relying on the current report text or an existing summary. Record:
-
-- canonical title, authors, date, and publication status;
+- canonical title, authors, date, version, and publication status;
 - official publisher or author URL;
-- research design, dataset, population, time period, and comparator;
-- exact definitions of the reported metrics;
-- exact reported numbers and uncertainty where available;
-- whether each result is observed, derived, model-calibrated, self-reported, or interpreted by the source authors;
-- stated limitations, conflicts of interest, and external-validity boundaries.
+- design, dataset, population, period, and comparator;
+- exact metric definitions;
+- exact numbers and uncertainty;
+- whether each result is observed, derived, model-calibrated, self-reported, or interpreted;
+- stated limitations and conflicts.
 
 ### 2. Locate every repository use
 
-Search the whole repository for:
+Search the entire repository for:
 
 - source ID;
 - author names;
-- publication title;
+- title fragments;
 - distinctive metric names;
-- every numeric value attributed to the source;
-- paraphrases of its findings that may not contain a citation.
+- every attributed number;
+- paraphrases that may not contain a citation.
 
 Inspect at minimum:
 
 - all files under `report/`;
-- `README.md`, including diagrams, tables, captions, the executive summary, and the claim-confidence map;
+- `README.md`, including tables, captions, diagrams, and claim-confidence entries;
 - all files under `protocols/`;
 - `REFERENCES.md`;
-- `evidence/SOURCES.md` and the relevant evidence indexes.
+- `evidence/SOURCES.md`;
+- evidence directory indexes.
 
-Do not rely only on the `Current use` field in `evidence/SOURCES.md`; verify actual repository usage.
+Do not rely only on the existing `Current use` field. Confirm actual usage and correct the field.
 
 ### 3. Build a claim-to-source trace
 
-For every repository statement supported by the source, record the relationship:
+For every material repository statement supported by the source, record:
 
-| Repository claim | Location | Source result | Relationship | Action |
+| Repository claim | Location | Exact source result | Relationship | Action |
 | --- | --- | --- | --- | --- |
-| Exact or paraphrased statement | File and section | Exact finding or record | Direct, derived, synthesis, scenario, or unsupported | Keep, qualify, correct, relocate, or remove |
+| Claim or paraphrase | File and section | Finding or record | Direct, derived, synthesis, scenario, or unsupported | Keep, qualify, correct, relocate, or remove |
 
-The trace may be included in the evidence brief, PR description, or review notes. It must be inspectable during review.
+The trace may live in the brief, PR description, or review notes, but it must be inspectable.
 
 ### 4. Verify numbers and units
 
-For every number derived from or attributed to the source:
+For every number:
 
-- confirm the numerator, denominator, unit, population, and time window;
-- distinguish percentage changes from percentage-point changes;
-- distinguish cumulative, average, median, long-run, and short-run effects;
-- preserve confidence intervals or uncertainty when they materially affect interpretation;
-- do not combine numbers from different samples, tools, studies, or periods into one apparent sequence without explicit labeling;
-- independently reproduce simple derived calculations where practical;
-- remove obsolete or rounded numbers that cannot be traced to the source.
+- confirm numerator, denominator, unit, population, and time window;
+- distinguish percentages from percentage points;
+- distinguish cumulative, average, median, short-run, and long-run effects;
+- preserve uncertainty where material;
+- reproduce simple derived calculations where practical;
+- do not combine different samples, studies, tools, or periods into one apparent sequence without explicit labeling;
+- remove obsolete or untraceable numbers.
 
-A number in a diagram or table is a claim and must be verified in the same way as prose.
+A number in a table, caption, or diagram is a claim and must be checked exactly like prose.
 
 ### 5. Verify argument fit
 
-Check whether the report uses the source for a conclusion its design can actually support.
+Check whether the repository uses the source for a conclusion its design can support.
 
 Ask:
 
-- Does observational evidence get presented as causal?
-- Does a bounded task result get generalized to an organization, industry, or economy?
-- Are experienced developers, junior developers, open-source contributors, and enterprise teams being treated as interchangeable populations?
-- Are activity measures being described as productivity, quality, shipped value, or business impact without justification?
-- Is source-author interpretation being presented as an observed finding?
-- Is repository synthesis clearly identified as synthesis?
-- Does contradictory or positive evidence receive equivalent treatment?
+- Is observational evidence presented as causal?
+- Is a bounded task result generalized to teams, enterprises, industries, or the economy?
+- Are different developer populations treated as interchangeable?
+- Is activity described as productivity, quality, shipped value, or business impact without justification?
+- Is source-author interpretation presented as an observed result?
+- Is repository synthesis clearly identified?
+- Are positive, null, mixed, and contradictory results treated fairly?
 
 Correct the argument even when the correction weakens the repository thesis.
 
 ### 6. Verify report integration
 
-For every report section using the source:
+For every report use:
 
-- ensure the source is introduced with enough methodological context;
-- link to the evidence brief rather than only to an external URL;
-- keep directly reported findings separate from repository inference;
-- expose material limitations near the claim, not only in the evidence brief;
-- remove duplicate retellings that drift into inconsistent wording;
-- update neighboring paragraphs when a corrected claim changes the logic of the section;
-- verify that chapter conclusions still follow after the correction.
+- explain what the source actually measured;
+- link to the evidence brief;
+- separate source findings from repository inference;
+- expose material limitations near the claim;
+- remove inconsistent duplicate retellings;
+- update neighboring paragraphs and chapter conclusions when needed.
 
-Do not treat a corrected citation as sufficient when the surrounding argument remains misleading.
+A corrected citation is not enough if the surrounding argument remains misleading.
 
 ### 7. Verify repository-level integration
 
 Reassess `README.md` when the source contributes to:
 
 - the executive summary;
-- the claim-confidence map;
-- the Evidence Map;
-- the Crisis Map or another diagram;
+- claim-confidence map;
+- Evidence Map;
+- Crisis Map or another diagram;
 - repository-level numeric claims;
-- the reading guide or source coverage description.
+- source coverage descriptions.
 
-Multi-source diagrams must label source boundaries. Do not visually connect numbers from unrelated studies as though they describe one observed causal chain.
+Multi-source diagrams must label source boundaries. Do not visually connect unrelated numbers as one observed causal chain.
 
 ### 8. Verify protocol implications
 
-Inspect protocols for rules, metrics, thresholds, or explanations that cite or implicitly rely on the source.
+Inspect all protocols for explicit or implicit reliance on the source.
 
-Then choose one explicit outcome:
+Choose and document exactly one outcome:
 
-- **No protocol change** — the source changes evidence description but not an operational decision.
-- **Protocol clarification** — wording or evidence boundaries must be corrected.
-- **Protocol change** — a metric, gate, risk boundary, escalation rule, disclosure requirement, or organizational control must change.
+- **No protocol change**
+- **Protocol clarification**
+- **Protocol change**
 
-Document the decision. Do not update a protocol merely to create symmetry with a report change.
+Do not modify a protocol merely for symmetry with a report change.
 
-### 9. Synchronize source records
+### 9. Synchronize records
 
-After all corrections:
+After corrections:
 
 - update the evidence brief;
-- update the source status and `Current use` locations in `evidence/SOURCES.md`;
-- update the relevant evidence-directory index;
+- update `Current use` in `evidence/SOURCES.md`;
+- update the relevant evidence index;
 - update `REFERENCES.md`;
-- verify all internal and external links;
-- record superseded versions, corrections, or removed claims explicitly.
+- verify internal and external links;
+- record superseded versions and removed claims.
 
-### 10. Declare completion
+### 10. Set the final status
 
-A source is fully integrated only when all of the following are true:
+When unresolved problems remain, set:
 
-- [ ] The original source has been read and classified.
-- [ ] A reviewed evidence brief exists.
-- [ ] Every repository mention and attributed number has been located.
-- [ ] Every material number has been checked against the source.
-- [ ] Claim strength matches the research design.
+```text
+Integration audit = Corrections required
+Last verified = —
+```
+
+Only after every required correction is merged and every completion check passes, set:
+
+```text
+Evidence review = Reviewed brief
+Integration audit = Verified
+Last verified = YYYY-MM-DD
+```
+
+Also update the brief's `Repository integration audit` section with the same status, outcome, locations, corrections, and date.
+
+The status in the brief and `evidence/SOURCES.md` must match.
+
+## Completion checklist
+
+A source may be marked `Verified` only when:
+
+- [ ] The original source and correct version were read.
+- [ ] A reviewed evidence brief exists and is indexed.
+- [ ] Every repository mention and attributed number was located.
+- [ ] A claim-to-source trace exists for all material uses.
+- [ ] Numbers, units, populations, and periods were checked.
+- [ ] Claim strength matches the source design.
 - [ ] Report arguments and nearby conclusions remain valid after corrections.
-- [ ] README tables and diagrams have been reassessed.
+- [ ] README tables and diagrams were reassessed.
 - [ ] Protocol implications have an explicit documented outcome.
-- [ ] `evidence/SOURCES.md`, evidence indexes, and `REFERENCES.md` are synchronized.
-- [ ] Links work and no obsolete parallel summary remains.
+- [ ] `Current use` lists actual repository locations.
+- [ ] `REFERENCES.md`, indexes, and links are synchronized.
+- [ ] The brief records the integration status and verification date.
+- [ ] `evidence/SOURCES.md` records `Integration audit = Verified` and the same date.
+- [ ] No unresolved correction remains.
 
-Do not mark a source as fully integrated merely because its evidence brief is complete.
+Never mark a source `Verified` merely because a brief, citation, or PR exists.
 
 ## Updating an existing source
 
-When a working paper becomes peer reviewed, a report is revised, or a dataset changes:
+When a working paper becomes peer reviewed, a report is revised, a dataset changes, or a relevant repository claim changes:
 
-1. Update `evidence/SOURCES.md`.
-2. Update the evidence brief and clearly note the new version.
-3. Re-run the full **Verifying the integration of each source** procedure.
-4. Reassess claim confidence.
-5. Update `REFERENCES.md`.
-6. Record corrections rather than silently preserving obsolete numbers.
+1. Set `Evidence review = Needs re-review` when the source itself changed materially.
+2. Set `Integration audit = Needs re-verification` when the source, report use, README diagram, or protocol implication changed materially.
+3. Clear `Last verified` to `—`.
+4. Update the evidence brief and record the new version.
+5. Re-run the entire integration procedure.
+6. Apply corrections.
+7. Restore `Reviewed brief` and `Verified` only after completion.
+8. Record the new verification date.
+
+Do not preserve obsolete numbers silently.
 
 ## Evidence-strength rules
 
-- Prefer the primary source over summaries when available.
+- Prefer primary sources over summaries.
 - Prefer official publisher or author links over reposts.
-- Do not infer causality from descriptive or observational evidence without explicit justification.
-- Do not present self-reported adoption or sentiment as production impact.
-- Do not treat arXiv status as peer review.
+- Do not infer causality from descriptive evidence without explicit justification.
+- Do not present sentiment or adoption as production impact.
+- Do not treat arXiv or working-paper status as peer review.
 - Do not treat company marketing as independent evidence.
 - Do not use one team's threshold as a universal standard.
-- Preserve null, mixed, and contradictory results.
+- Preserve null, mixed, contradictory, and positive evidence.
 
-## Change checklist
+## PR checklist
 
-Before opening a PR, confirm:
+Before opening or completing a source PR, confirm:
 
-- [ ] The source is registered in `evidence/SOURCES.md`.
+- [ ] The source is registered with both status fields.
 - [ ] Its evidence class is correct.
+- [ ] Publication status and version are explicit.
 - [ ] Findings and repository interpretation are separated.
-- [ ] Publication status is explicit.
-- [ ] Strong claims link to reviewed briefs where possible.
-- [ ] All repository uses and attributed numbers were searched for.
-- [ ] A claim-to-source trace was created for material uses.
+- [ ] Evidence-review status matches the actual brief state.
+- [ ] Integration-audit status matches the actual audit state.
+- [ ] All repository uses and attributed numbers were searched.
+- [ ] A claim-to-source trace exists.
+- [ ] Numeric values, units, samples, and periods were checked.
 - [ ] Report language matches the source design.
-- [ ] Numeric values, units, samples, and time windows were checked.
-- [ ] README claim confidence and diagrams were reassessed.
+- [ ] README claims and diagrams were reassessed.
 - [ ] Protocol implications have an explicit outcome.
-- [ ] `REFERENCES.md`, `evidence/SOURCES.md`, and indexes are synchronized.
+- [ ] `Current use`, `REFERENCES.md`, and indexes are synchronized.
+- [ ] The brief and registry show matching status and date.
 - [ ] Navigation links work.
-- [ ] The PR description lists evidence boundaries, corrections, and what the source does not establish.
+- [ ] The PR description lists boundaries, corrections, and unresolved work.
 
 ## Preferred PR structure
 
-For a substantial new source, use separate PRs when practical:
+For a substantial source, use separate PRs when practical:
 
 1. source registration and evidence brief;
 2. report integration and source-wide verification;
-3. repository-map or protocol updates, only if needed.
+3. repository-map or protocol updates, only when required.
 
-This keeps evidence review separate from argument and policy changes while requiring the complete integration verification before a source is considered finished.
+Do not set `Integration audit = Verified` until all required PRs are merged and the repository's default branch reflects the completed state.

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -1,102 +1,121 @@
 # Evidence Library
 
-This directory separates external evidence from the report's interpretation and from the repository's operational protocols.
+This directory separates empirical and documentary sources from the report's interpretation and from the repository's operational protocols.
 
-The goal is not to flatten every source into one confidence score. Different source types answer different questions and support different claims.
-
-## Start here
-
-- [`SOURCES.md`](SOURCES.md) — canonical registry of all external sources, classifications, review status, and report usage.
-- [`../REFERENCES.md`](../REFERENCES.md) — compact human-readable bibliography derived from the registry.
-- [`../AGENTS.md`](../AGENTS.md) — workflow for reading the repository and adding or updating evidence.
+The goal is not to flatten every source into a single confidence level. Different materials answer different questions and support different kinds of claims.
 
 ## Evidence classes
 
 ### [Primary empirical research](primary/README.md)
 
-Original studies, working papers, controlled experiments, large-scale observational analyses, and original measurement reports with inspectable methods.
+Original studies, working papers, controlled experiments, and large-scale observational analyses that directly report methods and results.
 
 Use these sources for claims about measured effects. Record publication status, dataset, method, directly observed findings, model-derived estimates, and limitations.
 
 ### [Primary documentary sources](documentary/README.md)
 
-First-party records such as filings, official documentation, standards, policies, and published engineering-system descriptions.
+First-party records such as annual filings, standards, official documentation, and published engineering-system descriptions.
 
-Use these sources for factual claims about what an organization reported, documented, spent, implemented, or required. Documentary evidence does not automatically establish independent validation or causal effect.
+Use these sources for factual records and institutional descriptions, not as independent proof of causal effects.
 
 ### [Secondary evidence](secondary/README.md)
 
-Industry reports, practitioner analyses, reviews, replications, critiques, and materials that synthesize or interpret primary evidence.
+Industry reports, practitioner analyses, replications, reviews, surveys, and other materials that synthesize or interpret primary data.
 
-Use these sources for triangulation, context, and hypothesis generation. Do not substitute them for an available primary source.
+Use these sources for triangulation and context, not as substitutes for an available primary source.
 
 ### [Theory and methodology](methodology/README.md)
 
-Frameworks used to interpret delivery-system behavior, such as Theory of Constraints, productivity models, queueing, reliability, and control concepts.
+Analytical frameworks used to interpret evidence, such as production theory, bottleneck analysis, and software-productivity frameworks.
 
-These sources support analytical reasoning. They are not direct empirical evidence of AI effects unless they include an empirical study.
+These sources structure reasoning but do not directly measure the effects of AI coding tools unless they also contain empirical analysis.
 
 ### [Datasets](datasets/README.md)
 
 Public or documented datasets used by cited research or maintained for independent analysis.
 
-Dataset entries should describe provenance, coverage, transformations, access conditions, licensing, and the claims the data can and cannot support.
+Dataset entries should describe provenance, coverage, transformations, access conditions, and the claims the data can and cannot support.
+
+## Canonical registry
+
+[`SOURCES.md`](SOURCES.md) is the canonical registry for every source.
+
+It tracks two separate states:
+
+- **Evidence review** — whether a source-oriented brief exists and is current.
+- **Integration audit** — whether every use of the source across the report, README, diagrams, references, and protocols has been checked.
+
+A source is fully processed only when:
+
+```text
+Evidence review = Reviewed brief
+Integration audit = Verified
+```
+
+The existence of a brief does not imply verified integration.
 
 ## Relationship to the rest of the repository
 
-- `evidence/SOURCES.md` is the canonical source registry.
-- evidence subdirectories contain reviewed source briefs and class-specific indexes.
-- `REFERENCES.md` is the compact bibliography and navigation view.
 - `report/` contains the Subprime Code Crisis argument and synthesis.
 - `protocols/` contains operational responses and decision rules.
-- `README.md` contains the repository-level claim-confidence and evidence maps.
-
-A bibliography entry is not an evidence brief. A registered source is not necessarily reviewed. A protocol is not empirical proof.
+- `evidence/` contains source-oriented briefs that distinguish reported findings from repository interpretation.
+- `evidence/SOURCES.md` contains classification, review status, integration status, verification date, and current use.
+- `REFERENCES.md` is the compact bibliography and navigation index.
+- `AGENTS.md` defines the mandatory source-processing and integration-verification procedure.
 
 ## Evidence brief standard
 
 Each evidence brief should include:
 
-1. Stable source ID from `SOURCES.md`.
-2. Full citation and canonical source links.
-3. Publication status, including whether the work is peer reviewed.
-4. Research question, documentary purpose, or methodological role.
-5. Scope, dataset, and methodology where applicable.
+1. Full citation and canonical links.
+2. Source ID.
+3. Publication status and version.
+4. Research question or documentary purpose.
+5. Dataset, population, period, comparator, and methodology where applicable.
 6. Directly observed or documented findings.
-7. Model-calibrated or derived findings.
-8. Source-author interpretation where material.
-9. Repository interpretation relevant to this project.
+7. Derived or model-calibrated findings.
+8. Source-author interpretation.
+9. Repository interpretation.
 10. What the source does not establish.
-11. Limitations, conflicts of interest, and external-validity risks.
-12. Links to report sections using the source.
-13. Links to any lawful local source copy retained in the repository.
+11. Limitations, conflicts, and external-validity risks.
+12. Repository locations using the source.
+13. A `Repository integration audit` section matching the status in `SOURCES.md`.
 
-A source may be registered before a full brief exists, but it must be marked **Registered; brief pending**. Pending sources should not carry load-bearing strong claims without visible qualification.
+Use this audit template:
+
+```markdown
+## Repository integration audit
+
+- Integration status: Not started | In progress | Corrections required | Verified | Needs re-verification
+- Repository search completed:
+- Report mentions checked:
+- Numeric claims checked:
+- README claims and diagrams checked:
+- Protocol outcome: No change | Clarification | Operational change
+- Corrections made:
+- Current-use locations confirmed:
+- Verification date:
+```
 
 ## Interpretation labels
 
 Use these labels where useful:
 
 - **Observed:** directly reported from empirical analysis.
-- **Documented:** explicitly stated in a first-party record.
-- **Derived:** calculated from reported results without introducing a new causal claim.
+- **Documented:** stated in an authoritative first-party record.
+- **Derived:** calculated from reported results without adding a new causal claim.
 - **Model-calibrated:** produced by a fitted or calibrated model rather than directly measured.
-- **Source interpretation:** the source author's explanation or framing.
+- **Source-author interpretation:** interpretation offered by the source authors.
 - **Repository interpretation:** the Subprime Code Crisis project's synthesis or application.
-- **Not established:** a plausible claim that the source does not demonstrate.
+- **Not established:** a plausible claim that the source does not itself demonstrate.
 
-## Source lifecycle
+## Completion rule
 
-```mermaid
-flowchart LR
-    A[Discover source] --> B[Register in SOURCES.md]
-    B --> C[Classify source]
-    C --> D[Create evidence brief]
-    D --> E[Update class index]
-    E --> F[Integrate into report]
-    F --> G[Reassess README claims]
-    G --> H[Reassess protocols if decisions change]
-    H --> I[Update REFERENCES.md and navigation]
-```
+Do not mark a source `Verified` merely because:
 
-Detailed execution rules are in [`AGENTS.md`](../AGENTS.md).
+- a brief exists;
+- a citation was added;
+- a PR was merged;
+- a report paragraph was corrected.
+
+`Verified` requires the complete repository-wide procedure in `AGENTS.md`, synchronized status in the brief and `SOURCES.md`, and a recorded verification date.

--- a/evidence/SOURCES.md
+++ b/evidence/SOURCES.md
@@ -2,63 +2,89 @@
 
 This file is the canonical registry for external material used by the repository.
 
-`REFERENCES.md` is the compact human-readable bibliography. Evidence subdirectories contain reviewed briefs. This registry records classification and review status for every source, including sources whose briefs are still pending.
+`REFERENCES.md` is the compact human-readable bibliography. Evidence subdirectories contain source-oriented briefs. This registry records both evidence-review status and repository-integration status for every source.
 
-## Status values
+A source is fully processed only when:
 
-- **Reviewed brief** — a source-oriented brief exists and has been integrated with explicit limitations.
-- **Registered; brief pending** — the source is used or proposed, but the full evidence brief has not yet been completed.
-- **Documentary entry** — the source supports a factual record rather than an empirical effect estimate.
-- **Methodology entry** — the source provides an interpretive framework rather than direct evidence of AI effects.
+- **Evidence review** is `Reviewed brief`; and
+- **Integration audit** is `Verified`.
+
+These are separate states. Creating a brief does not prove that every report claim, number, diagram, reference, and protocol implication has been checked.
+
+## Evidence-review status
+
+- **Registered** — the source is known to the repository but no brief is complete.
+- **Brief in progress** — active review is underway.
+- **Reviewed brief** — a source-oriented brief exists and records methods, findings, limitations, and repository interpretation.
+- **Needs re-review** — the source changed, was superseded, or requires material correction.
+
+Documentary and methodology sources use the same review lifecycle. Their briefs evaluate records or frameworks rather than empirical effects.
+
+## Integration-audit status
+
+- **Not started** — no repository-wide source integration audit has been performed.
+- **In progress** — repository mentions, numbers, arguments, diagrams, references, and protocol implications are being checked.
+- **Corrections required** — the audit found unresolved problems.
+- **Verified** — the complete procedure in `AGENTS.md` has been completed and all required corrections have been integrated.
+- **Needs re-verification** — a source version, repository claim, diagram, or relevant protocol changed after the last verification.
+
+`Last verified` is the date on which the integration audit reached `Verified`. Leave it as `—` for every other status.
 
 ## Primary empirical research
 
-| ID | Source | Status | Can support | Current use |
-| --- | --- | --- | --- | --- |
-| **P-2026-01** | Demirer, Musolff & Yang, *Writing Code vs. Shipping Code: Productivity Effects Across Generations of AI Coding Tools*, NBER Working Paper 35275 | [Reviewed brief](primary/2026-writing-code-vs-shipping-code.md) | Measured attenuation from coding activity toward projects, releases, and early marketplace use within the studied setting | `report/01_the_illusion.md`; `report/02_broken_mechanics.md` |
-| **P-2025-01** | METR, *Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity* | Registered; brief pending | Randomized evidence about experienced developers completing familiar open-source tasks with early-2025 tools | Report claims about experienced-developer task completion |
-| **P-2025-02** | METR, *Measuring AI Ability to Complete Long Tasks* | Registered; brief pending | Agent task-completion performance as task duration increases under the study's benchmark design | Agent capability and task-horizon discussion |
-| **P-2025-03** | Xu et al., *AI-Assisted Programming Decreases the Productivity of Experienced Developers* | Registered; brief pending | Large-scale developer-output and review-load associations reported by the authors | Senior-load and productivity discussion |
-| **P-2026-02** | Agarwal et al., *AI IDEs or Autonomous Agents? Measuring the Impact of Coding Agents* | Registered; brief pending | Reported static-analysis and code-structure differences in the study sample | Complexity and quality-risk discussion |
-| **P-2023-01** | Peng et al., *The Impact of AI on Developer Productivity* | Registered; brief pending | Controlled evidence of task-completion acceleration in a bounded greenfield task | Positive productivity evidence and boundary conditions |
-| **P-2025-04** | GitClear, *AI Assistant Code Quality 2025 Research* | Registered; brief pending | Original commercial measurement of code-change patterns, subject to methodology and conflict review | Churn, duplication, and reuse discussion |
-| **P-2025-05** | GitClear, *How Much More Productive Are AI-Powered Developers?* | Registered; brief pending | Original commercial productivity measurement, subject to methodology and conflict review | Net-output and rework discussion |
+| ID | Source | Evidence review | Integration audit | Last verified | Can support | Current use |
+| --- | --- | --- | --- | --- | --- | --- |
+| **P-2026-01** | Demirer, Musolff & Yang, *Writing Code vs. Shipping Code: Productivity Effects Across Generations of AI Coding Tools*, NBER Working Paper 35275 | [Reviewed brief](primary/2026-writing-code-vs-shipping-code.md) | Not started | — | Measured attenuation from coding activity toward projects, releases, and early marketplace use within the studied setting | `report/01_the_illusion.md`; `report/02_broken_mechanics.md` |
+| **P-2025-01** | METR, *Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity* | Registered | Not started | — | Randomized evidence about experienced developers completing familiar open-source tasks with early-2025 tools | Report claims about experienced-developer task completion |
+| **P-2025-02** | METR, *Measuring AI Ability to Complete Long Tasks* | Registered | Not started | — | Agent task-completion performance as task duration increases under the study's benchmark design | Agent capability and task-horizon discussion |
+| **P-2025-03** | Xu et al., *AI-Assisted Programming Decreases the Productivity of Experienced Developers* | Registered | Not started | — | Large-scale developer-output and review-load associations reported by the authors | Senior-load and productivity discussion |
+| **P-2026-02** | Agarwal et al., *AI IDEs or Autonomous Agents? Measuring the Impact of Coding Agents* | Registered | Not started | — | Reported static-analysis and code-structure differences in the study sample | Complexity and quality-risk discussion |
+| **P-2023-01** | Peng et al., *The Impact of AI on Developer Productivity* | Registered | Not started | — | Controlled evidence of task-completion acceleration in a bounded greenfield task | Positive productivity evidence and boundary conditions |
+| **P-2025-04** | GitClear, *AI Assistant Code Quality 2025 Research* | Registered | Not started | — | Original commercial measurement of code-change patterns, subject to methodology and conflict review | Churn, duplication, and reuse discussion |
+| **P-2025-05** | GitClear, *How Much More Productive Are AI-Powered Developers?* | Registered | Not started | — | Original commercial productivity measurement, subject to methodology and conflict review | Net-output and rework discussion |
 
 ## Primary documentary sources
 
-| ID | Source | Status | Can support | Current use |
-| --- | --- | --- | --- | --- |
-| **D-2019-01** | *Software Engineering at Google* and associated first-party engineering documentation | Documentary entry; brief pending | Descriptions of Google's engineering infrastructure and practices | Infrastructure and verification-capacity discussion |
-| **D-2024-01** | Alphabet annual filings | Documentary entry; brief pending | Alphabet-reported capital expenditure and business records | AI infrastructure-spending discussion |
-| **D-2024-02** | Meta annual filings | Documentary entry; brief pending | Meta-reported capital expenditure and business records | AI infrastructure-spending discussion |
-| **D-2024-03** | Microsoft annual filings | Documentary entry; brief pending | Microsoft-reported capital expenditure and business records | AI infrastructure-spending discussion |
+| ID | Source | Evidence review | Integration audit | Last verified | Can support | Current use |
+| --- | --- | --- | --- | --- | --- | --- |
+| **D-2019-01** | *Software Engineering at Google* and associated first-party engineering documentation | Registered | Not started | — | Descriptions of Google's engineering infrastructure and practices | Infrastructure and verification-capacity discussion |
+| **D-2024-01** | Alphabet annual filings | Registered | Not started | — | Alphabet-reported capital expenditure and business records | AI infrastructure-spending discussion |
+| **D-2024-02** | Meta annual filings | Registered | Not started | — | Meta-reported capital expenditure and business records | AI infrastructure-spending discussion |
+| **D-2024-03** | Microsoft annual filings | Registered | Not started | — | Microsoft-reported capital expenditure and business records | AI infrastructure-spending discussion |
 
 ## Secondary evidence and industry context
 
-| ID | Source | Status | Can support | Current use |
-| --- | --- | --- | --- | --- |
-| **S-2025-01** | Deloitte, *State of Generative AI in the Enterprise* | Registered; brief pending | Surveyed enterprise adoption, expectations, and reported constraints | Adoption and organizational-context discussion |
-| **S-2025-02** | McKinsey enterprise AI reporting, currently linked through a third-party summary | Registered; replacement primary link required | Context on reported adoption and impact; not load-bearing until the original report is linked and reviewed | Market-sentiment discussion |
-| **S-2025-03** | Artur Markus, *The Inference Cost Paradox* | Registered; brief pending | Practitioner interpretation of enterprise AI spending and Jevons-style effects | Cost-paradox discussion |
-| **S-2026-01** | Andreas Horn, *The Most Important Chart in AI* | Registered; brief pending | Practitioner framing and visual interpretation | Market and capability narrative context |
-| **S-2025-04** | SoftwareSeni, *Why AI Coding Speed Gains Disappear in Code Reviews* | Registered; brief pending | Practitioner synthesis about review bottlenecks | Review-bottleneck framing |
-| **S-2025-05** | TechnoDiaries, *Post-Copilot Burnout* | Registered; brief pending | Practitioner reporting and hypothesis generation | Senior-bottleneck and burnout context |
+| ID | Source | Evidence review | Integration audit | Last verified | Can support | Current use |
+| --- | --- | --- | --- | --- | --- | --- |
+| **S-2025-01** | Deloitte, *State of Generative AI in the Enterprise* | Registered | Not started | — | Surveyed enterprise adoption, expectations, and reported constraints | Adoption and organizational-context discussion |
+| **S-2025-02** | McKinsey enterprise AI reporting, currently linked through a third-party summary | Registered; original source required | Not started | — | Context on reported adoption and impact; not load-bearing until the original report is linked and reviewed | Market-sentiment discussion |
+| **S-2025-03** | Artur Markus, *The Inference Cost Paradox* | Registered | Not started | — | Practitioner interpretation of enterprise AI spending and Jevons-style effects | Cost-paradox discussion |
+| **S-2026-01** | Andreas Horn, *The Most Important Chart in AI* | Registered | Not started | — | Practitioner framing and visual interpretation | Market and capability narrative context |
+| **S-2025-04** | SoftwareSeni, *Why AI Coding Speed Gains Disappear in Code Reviews* | Registered | Not started | — | Practitioner synthesis about review bottlenecks | Review-bottleneck framing |
+| **S-2025-05** | TechnoDiaries, *Post-Copilot Burnout* | Registered | Not started | — | Practitioner reporting and hypothesis generation | Senior-bottleneck and burnout context |
 
 ## Theory and methodology
 
-| ID | Source | Status | Can support | Current use |
-| --- | --- | --- | --- | --- |
-| **M-1984-01** | Eliyahu M. Goldratt, *The Goal: A Process of Ongoing Improvement* | Methodology entry; brief pending | Theory of Constraints concepts such as bottlenecks, inventory, and local optimization | Delivery-system interpretation throughout the report |
+| ID | Source | Evidence review | Integration audit | Last verified | Can support | Current use |
+| --- | --- | --- | --- | --- | --- | --- |
+| **M-1984-01** | Eliyahu M. Goldratt, *The Goal: A Process of Ongoing Improvement* | Registered | Not started | — | Theory of Constraints concepts such as bottlenecks, inventory, and local optimization | Delivery-system interpretation throughout the report |
 
 ## Datasets
 
 Dataset-level entries should be added to `datasets/README.md` when the repository independently uses, republishes, or analyzes a dataset. Datasets merely described inside an evidence brief do not need a separate registry entry unless they become reusable repository assets.
 
+Dataset registry entries must use the same `Evidence review`, `Integration audit`, and `Last verified` fields.
+
 ## Registry maintenance rules
 
 1. Register a source before adding it to the report.
-2. Do not mark a source `Reviewed brief` until a source-oriented brief exists.
-3. A pending brief may support provisional or low-load claims, but strong claims should link to a reviewed brief.
-4. Replace secondary links with original sources whenever possible.
-5. When publication status or source content changes, update this registry, the brief, report usage, and `REFERENCES.md` together.
-6. Preserve contradictory and negative evidence; classification is independent of whether a source supports the repository thesis.
+2. Set `Evidence review` to `Reviewed brief` only after a source-oriented brief exists and is indexed.
+3. Set `Integration audit` to `Verified` only after completing every step in **Verifying the integration of each source** in `AGENTS.md`.
+4. Never infer `Verified` from the existence of a brief, citation, or prior PR.
+5. Record the verification date only when the status becomes `Verified`.
+6. If a source version changes, set `Evidence review` to `Needs re-review` and `Integration audit` to `Needs re-verification` until both procedures are rerun.
+7. If a report claim, README diagram, or protocol materially relying on a source changes, set its integration status to `Needs re-verification`.
+8. A pending brief may support provisional or low-load claims, but strong claims should link to a reviewed brief.
+9. Replace secondary links with original sources whenever possible.
+10. Keep `Current use` synchronized with actual repository usage discovered during the audit.
+11. Preserve contradictory, null, mixed, and positive evidence; classification and status are independent of whether a source supports the repository thesis.

--- a/evidence/primary/2026-writing-code-vs-shipping-code.md
+++ b/evidence/primary/2026-writing-code-vs-shipping-code.md
@@ -152,3 +152,17 @@ This source is suitable for claims about:
 - the need to measure releases and usage rather than relying only on code-production metrics.
 
 It should be paired with separate research when making claims about code quality, defects, review burden, maintainability, security, or long-term organizational outcomes.
+
+## Repository integration audit
+
+- **Integration status:** Not started
+- **Repository search completed:** No
+- **Report mentions checked:** Not yet
+- **Numeric claims checked:** The brief's numbers were checked against the source; repository-wide uses have not yet been audited
+- **README claims and diagrams checked:** Not yet
+- **Protocol outcome:** Not yet assessed
+- **Corrections made:** None recorded through the complete integration procedure
+- **Current-use locations confirmed:** No; the registry locations remain provisional until repository-wide search
+- **Verification date:** —
+
+This source has a reviewed evidence brief but is not fully processed. It must remain `Integration audit = Not started` in `evidence/SOURCES.md` until the complete procedure in `AGENTS.md` has been run and all required corrections are merged.


### PR DESCRIPTION
## Summary

Extends the source-integration procedure into a complete status model and mandatory agent workflow.

The repository previously distinguished reviewed briefs from pending briefs, but it did not visibly distinguish a completed evidence brief from a completed repository-wide integration audit. This PR fixes that gap.

## Changes

### `evidence/SOURCES.md`

Adds separate status fields for every source:

- **Evidence review**
  - Registered
  - Brief in progress
  - Reviewed brief
  - Needs re-review
- **Integration audit**
  - Not started
  - In progress
  - Corrections required
  - Verified
  - Needs re-verification
- **Last verified** date

A source is now considered fully processed only when:

```text
Evidence review = Reviewed brief
Integration audit = Verified
```

All current sources are migrated to the new structure. The NBER source remains `Reviewed brief` but is explicitly marked `Integration audit = Not started`, because its repository-wide integration has not yet passed the new procedure.

### `AGENTS.md`

Reworks source processing into one mandatory end-to-end flow:

1. register and classify the source;
2. set initial status fields;
3. create and index the evidence brief;
4. mark the integration audit `In progress`;
5. locate every repository use and attributed number;
6. build a claim-to-source trace;
7. verify numbers, units, populations, periods, and argument fit;
8. verify report, README, diagrams, references, and protocol implications;
9. synchronize the brief and registry;
10. set `Verified` only after all corrections are merged.

It also defines when a source must move to `Needs re-review` or `Needs re-verification`.

### Evidence brief audit record

Adds a `Repository integration audit` section to the existing NBER evidence brief, recording that the brief is reviewed but repository integration has not yet been verified.

### `evidence/README.md`

Documents the two-state model, required audit template, and completion rule for all future evidence briefs.

## Files changed

- `AGENTS.md`
- `evidence/SOURCES.md`
- `evidence/README.md`
- `evidence/primary/2026-writing-code-vs-shipping-code.md`

## Important behavior

Agents must not infer `Verified` from:

- the existence of an evidence brief;
- a citation;
- a merged PR;
- a corrected report paragraph.

The brief and `evidence/SOURCES.md` must show matching integration status and verification date.

## Review focus

1. Are evidence review and integration verification now visibly separate?
2. Is the status transition mandatory and unambiguous for agents?
3. Is it clear when verification must be invalidated and rerun?
4. Does the NBER entry honestly represent current work as reviewed but not yet fully integrated?