### PR TITLE
Clarify source workflow selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,37 +2,37 @@
 
 ## Purpose
 
-This file defines how human contributors and AI agents should read, modify, and extend this repository without mixing evidence, interpretation, and operational guidance.
+This file defines how human contributors and AI agents must process sources and modify this repository without mixing evidence, repository interpretation, operational guidance, and navigation metadata.
 
-The repository has four distinct layers:
+The repository has four layers:
 
-1. **Evidence** — what external sources actually report.
+1. **Evidence** — what external sources report.
 2. **Report** — the Subprime Code Crisis synthesis and argument.
-3. **Protocols** — practical controls derived from the risk analysis.
-4. **Repository maps** — navigation, claim confidence, source status, and bibliography.
+3. **Protocols** — operational responses derived from the risk analysis.
+4. **Repository maps** — navigation, source status, claim confidence, diagrams, and bibliography.
 
 Do not collapse these layers.
 
 ## Read order
 
-Before making changes, read in this order:
+Before changing source-related content, read:
 
-1. `README.md` — scope, major claims, evidence map, and repository structure.
-2. `evidence/README.md` — source taxonomy and evidence-brief standard.
-3. `evidence/SOURCES.md` — canonical source registry, evidence-review status, integration-audit status, and current use.
-4. The relevant evidence brief under `evidence/`, when one exists.
-5. Every relevant chapter under `report/`.
-6. Every relevant operational response under `protocols/`.
+1. `README.md` — scope, major claims, maps, and repository structure.
+2. `evidence/README.md` — evidence taxonomy and brief standard.
+3. `evidence/SOURCES.md` — canonical source inventory and status database.
+4. The relevant evidence brief, when one exists.
+5. Every relevant file under `report/`.
+6. Every relevant file under `protocols/`.
 7. `REFERENCES.md` — compact bibliography.
-8. `CONTRIBUTING.md` — contribution and disclosure requirements.
+8. `CONTRIBUTING.md` — contributor requirements.
 
-`REFERENCES.md` is not the canonical status database. `evidence/SOURCES.md` is.
+`evidence/SOURCES.md` is canonical. `REFERENCES.md` is not a status database.
 
 ## Repository boundaries
 
-### Evidence layer
+### Evidence
 
-Evidence entries describe external material. They must separate:
+Evidence briefs must separate:
 
 - directly observed or documented findings;
 - derived calculations;
@@ -42,29 +42,26 @@ Evidence entries describe external material. They must separate:
 - claims not established by the source;
 - limitations, conflicts, and external-validity risks.
 
-Never write a repository conclusion as though it were a finding reported by a source.
+Never present a repository conclusion as a finding directly reported by a source.
 
-### Report layer
+### Report
 
-The report may combine multiple sources and systems reasoning. Every material factual claim must trace to:
+Every material factual claim must trace to a registered source. Strong or load-bearing claims should trace to a reviewed evidence brief.
 
-- a reviewed evidence brief; or
-- a registered source whose brief is explicitly marked pending.
+Use bounded language when the source design cannot support a causal, universal, or enterprise-wide conclusion.
 
-Use bounded language when the design cannot support a strong causal or general claim.
+### Protocols
 
-### Protocol layer
-
-Protocols are operating patterns, not empirical proof. A source may motivate a protocol, but no local threshold, gate, role, workflow, or control is universally validated unless evidence directly supports that claim.
+Protocols are operating patterns, not empirical proof. Do not present a local threshold, role, gate, escalation rule, workflow, or control as universally validated unless evidence directly establishes it.
 
 ### Repository maps
 
-The following must remain synchronized:
+Keep these synchronized:
 
 - `evidence/SOURCES.md` — canonical source and status registry;
-- evidence directory indexes — reviewed briefs available in each class;
+- evidence-directory indexes — available briefs;
 - `REFERENCES.md` — compact bibliography;
-- `README.md` — repository-level claims, maps, diagrams, and source coverage.
+- `README.md` — repository-level claims, diagrams, source coverage, and navigation.
 
 ## Source state model
 
@@ -96,34 +93,85 @@ Evidence review = Reviewed brief
 Integration audit = Verified
 ```
 
-The existence of a brief does not imply that report integration has been verified.
+`Last verified` contains a date only when `Integration audit = Verified`. Otherwise use `—`.
 
-`Last verified` must contain a date only when `Integration audit = Verified`. Otherwise use `—`.
+The existence of a brief, citation, merged PR, or corrected paragraph does not imply verified integration.
 
-## Mandatory source-processing flow
+## Choose the correct flow first
 
-Use this flow for every new source and every legacy source already used by the repository.
+Select one primary flow before editing anything.
 
-Do not skip steps, and do not mark the source complete after creating the brief.
+### Flow A — Add a new source
 
-### Step 1 — Register the source
+Use when the source is not listed in `evidence/SOURCES.md`.
 
-Add the source to `evidence/SOURCES.md` before adding or revising report claims.
+1. Register and classify it.
+2. Set `Evidence review = Registered`, `Integration audit = Not started`, `Last verified = —`.
+3. Complete the evidence-review procedure.
+4. Complete the integration-audit procedure.
+5. Synchronize all records.
+6. Mark `Verified` only after all required corrections are merged.
 
-Record:
+### Flow B — Process a legacy registered source
+
+Use when the source is already cited or registered but lacks a current reviewed brief or completed integration audit.
+
+1. Confirm or correct its ID, class, canonical link, publication status, and proposed `Current use`.
+2. Do not create a duplicate registry entry.
+3. Complete evidence review if no current reviewed brief exists.
+4. Audit every existing repository use.
+5. Correct claims, diagrams, references, and protocol implications.
+6. Mark `Verified` only after all corrections are merged.
+
+### Flow C — Update a changed or superseded source
+
+Use when a paper, report, filing, dataset, or methodology source changes, is superseded, or becomes peer reviewed.
+
+1. Set `Evidence review = Needs re-review`.
+2. Set `Integration audit = Needs re-verification`.
+3. Clear `Last verified` to `—`.
+4. Record the new version.
+5. Re-run evidence review.
+6. Re-run the complete integration audit.
+7. Restore `Reviewed brief` and `Verified` only after completion.
+
+### Flow D — Re-verify changed repository content
+
+Use when the source itself is unchanged, but a report claim, README diagram, summary, protocol, or derived calculation relying on it changes materially.
+
+1. Keep `Evidence review = Reviewed brief` unless the brief itself is inadequate.
+2. Set `Integration audit = Needs re-verification`.
+3. Clear `Last verified` to `—`.
+4. Re-run the integration audit for the affected source.
+5. Restore `Verified` only after the changed repository state is checked and merged.
+
+### Flow E — Discover newer or missing evidence
+
+Use after the current source backlog has been processed far enough to expose real evidence gaps.
+
+1. Identify weak claims, stale evidence, missing primary sources, contradictions, positive evidence, null results, and replication gaps.
+2. Search for newer, stronger, original, peer-reviewed, contradictory, null, and positive evidence.
+3. Do not insert search results directly into the report.
+4. Route every selected source through Flow A.
+5. For systematic or claim-critical searches, record rejected candidates and reasons.
+
+Freshness search is not a substitute for validating sources already used by the repository.
+
+## Registration and classification
+
+Register a source before adding or revising report claims. Record:
 
 - stable source ID;
 - canonical title and authors or publisher;
-- year and publication status;
+- year, version, and publication status;
 - canonical URL;
 - evidence class;
-- `Evidence review = Registered`;
-- `Integration audit = Not started`;
-- `Last verified = —`;
+- both status fields;
+- `Last verified`;
 - what the source can support;
 - known or proposed repository use.
 
-Use IDs in the form:
+Source ID forms:
 
 - `P-YYYY-NN` — primary empirical research;
 - `D-YYYY-NN` — primary documentary source;
@@ -131,9 +179,7 @@ Use IDs in the form:
 - `M-YYYY-NN` — methodology or theory;
 - `DS-YYYY-NN` — dataset.
 
-### Step 2 — Classify the source
-
-Choose exactly one primary class:
+Choose one primary class:
 
 - `evidence/primary/`
 - `evidence/documentary/`
@@ -143,44 +189,46 @@ Choose exactly one primary class:
 
 Classification describes what the source is, not whether it supports the repository thesis.
 
-### Step 3 — Start the evidence review
+## Evidence-review procedure
 
-When review begins, set:
+### 1. Start review
+
+Set:
 
 ```text
 Evidence review = Brief in progress
-Integration audit = Not started
 Last verified = —
 ```
 
+For a new or legacy source, keep `Integration audit = Not started`. For Flow C, keep `Needs re-verification` until the audit starts.
+
 Read the original source, not only a summary or the repository's existing interpretation.
 
-### Step 4 — Create the evidence brief
+### 2. Create or update the brief
 
-Create a kebab-case Markdown file in the correct evidence directory.
-
-Include:
+The brief must include:
 
 1. Source ID and full citation.
-2. Publication status and version.
+2. Publication status and exact version.
 3. Research question or documentary purpose.
-4. Scope, dataset, population, time period, comparator, and methodology.
+4. Scope, dataset, population, period, comparator, and methodology.
 5. Directly observed or documented findings.
 6. Derived or model-calibrated findings.
 7. Source-author interpretation.
-8. Repository-relevant interpretation.
+8. Repository interpretation.
 9. What the source does not establish.
 10. Limitations, conflicts, and external-validity risks.
 11. Known repository locations using the source.
 12. A `Repository integration audit` section.
 
-Use this section template:
+Use this audit template:
 
 ```markdown
 ## Repository integration audit
 
 - Integration status: Not started | In progress | Corrections required | Verified | Needs re-verification
 - Repository search completed:
+- Claim-to-source trace location:
 - Report mentions checked:
 - Numeric claims checked:
 - README claims and diagrams checked:
@@ -190,51 +238,50 @@ Use this section template:
 - Verification date:
 ```
 
-When the brief is complete and indexed, set:
+### 3. Complete evidence review
+
+Add the brief to the relevant evidence-directory index and set:
 
 ```text
 Evidence review = Reviewed brief
-Integration audit = Not started
-Last verified = —
 ```
 
-This is not completion of the source-processing flow.
+A reviewed brief does not complete source processing.
 
-### Step 5 — Start the integration audit
+## Integration-audit procedure
 
-Before changing report text, set:
+### 1. Start the audit
+
+Set in both the registry and brief:
 
 ```text
 Integration audit = In progress
 Last verified = —
 ```
 
-Then execute the complete procedure below.
+### 2. Establish source ground truth
 
-## Verifying the integration of each source
+Confirm:
 
-### 1. Establish source ground truth
-
-Record from the original source:
-
-- canonical title, authors, date, version, and publication status;
-- official publisher or author URL;
+- title, authors, date, version, and publication status;
+- official URL;
 - design, dataset, population, period, and comparator;
 - exact metric definitions;
 - exact numbers and uncertainty;
-- whether each result is observed, derived, model-calibrated, self-reported, or interpreted;
-- stated limitations and conflicts.
+- whether results are observed, derived, model-calibrated, self-reported, or interpreted;
+- limitations and conflicts.
 
-### 2. Locate every repository use
+### 3. Locate every repository use
 
 Search the entire repository for:
 
 - source ID;
-- author names;
+- author and organization names;
 - title fragments;
 - distinctive metric names;
 - every attributed number;
-- paraphrases that may not contain a citation.
+- uncited paraphrases;
+- diagrams, captions, summaries, and protocol language that implicitly depend on the source.
 
 Inspect at minimum:
 
@@ -243,109 +290,107 @@ Inspect at minimum:
 - all files under `protocols/`;
 - `REFERENCES.md`;
 - `evidence/SOURCES.md`;
-- evidence directory indexes.
+- evidence-directory indexes.
 
-Do not rely only on the existing `Current use` field. Confirm actual usage and correct the field.
+Do not trust the existing `Current use` field without confirming actual usage.
 
-### 3. Build a claim-to-source trace
+### 4. Build a claim-to-source trace
 
-For every material repository statement supported by the source, record:
+For every material use, record:
 
 | Repository claim | Location | Exact source result | Relationship | Action |
 | --- | --- | --- | --- | --- |
 | Claim or paraphrase | File and section | Finding or record | Direct, derived, synthesis, scenario, or unsupported | Keep, qualify, correct, relocate, or remove |
 
-The trace may live in the brief, PR description, or review notes, but it must be inspectable.
+The trace must be inspectable and its location recorded in the brief.
 
-### 4. Verify numbers and units
+### 5. Verify numbers and units
 
 For every number:
 
 - confirm numerator, denominator, unit, population, and time window;
 - distinguish percentages from percentage points;
 - distinguish cumulative, average, median, short-run, and long-run effects;
-- preserve uncertainty where material;
+- preserve material uncertainty;
 - reproduce simple derived calculations where practical;
-- do not combine different samples, studies, tools, or periods into one apparent sequence without explicit labeling;
+- do not visually or rhetorically combine different studies, samples, tools, or periods into one observed sequence without explicit labeling;
 - remove obsolete or untraceable numbers.
 
-A number in a table, caption, or diagram is a claim and must be checked exactly like prose.
+A number in a table, caption, or diagram is a claim.
 
-### 5. Verify argument fit
+### 6. Verify argument fit
 
-Check whether the repository uses the source for a conclusion its design can support.
+Check whether the source design supports the repository conclusion.
 
-Ask:
+Ask whether:
 
-- Is observational evidence presented as causal?
-- Is a bounded task result generalized to teams, enterprises, industries, or the economy?
-- Are different developer populations treated as interchangeable?
-- Is activity described as productivity, quality, shipped value, or business impact without justification?
-- Is source-author interpretation presented as an observed result?
-- Is repository synthesis clearly identified?
-- Are positive, null, mixed, and contradictory results treated fairly?
+- observational evidence is presented as causal;
+- bounded tasks are generalized to teams, enterprises, industries, or the economy;
+- different developer populations are treated as interchangeable;
+- activity is described as productivity, quality, shipped value, or business impact without justification;
+- source-author interpretation is presented as an observed result;
+- repository synthesis is clearly identified;
+- positive, null, mixed, contradictory, and unfavorable findings are treated fairly.
 
-Correct the argument even when the correction weakens the repository thesis.
+Correct the argument even when this weakens the repository thesis.
 
-### 6. Verify report integration
+### 7. Verify report integration
 
 For every report use:
 
-- explain what the source actually measured;
+- explain what the source measured;
 - link to the evidence brief;
-- separate source findings from repository inference;
+- separate findings from repository inference;
 - expose material limitations near the claim;
 - remove inconsistent duplicate retellings;
 - update neighboring paragraphs and chapter conclusions when needed.
 
-A corrected citation is not enough if the surrounding argument remains misleading.
+A corrected citation is insufficient if the surrounding argument remains misleading.
 
-### 7. Verify repository-level integration
+### 8. Verify README and repository maps
 
-Reassess `README.md` when the source contributes to:
+Reassess:
 
-- the executive summary;
+- executive summary;
 - claim-confidence map;
 - Evidence Map;
-- Crisis Map or another diagram;
+- Crisis Map and other diagrams;
 - repository-level numeric claims;
 - source coverage descriptions.
 
-Multi-source diagrams must label source boundaries. Do not visually connect unrelated numbers as one observed causal chain.
+Multi-source diagrams must label source boundaries and must not present unrelated numbers as one measured causal chain.
 
-### 8. Verify protocol implications
+### 9. Verify protocol implications
 
-Inspect all protocols for explicit or implicit reliance on the source.
-
-Choose and document exactly one outcome:
+Inspect every protocol for explicit or implicit reliance on the source. Document exactly one outcome:
 
 - **No protocol change**
 - **Protocol clarification**
 - **Protocol change**
 
-Do not modify a protocol merely for symmetry with a report change.
+Do not change a protocol merely for symmetry with a report change.
 
-### 9. Synchronize records
+### 10. Synchronize records
 
 After corrections:
 
-- update the evidence brief;
-- update `Current use` in `evidence/SOURCES.md`;
+- update the brief;
+- update actual `Current use` locations in `evidence/SOURCES.md`;
 - update the relevant evidence index;
 - update `REFERENCES.md`;
-- verify internal and external links;
+- verify links;
 - record superseded versions and removed claims.
 
-### 10. Set the final status
+### 11. Set final status
 
-When unresolved problems remain, set:
+When unresolved problems remain:
 
 ```text
 Integration audit = Corrections required
 Last verified = —
 ```
 
-Only after every required correction is merged and every completion check passes, set:
+Only after every required correction is merged and every completion check passes:
 
 ```text
 Evidence review = Reviewed brief
@@ -353,84 +398,33 @@ Integration audit = Verified
 Last verified = YYYY-MM-DD
 ```
 
-Also update the brief's `Repository integration audit` section with the same status, outcome, locations, corrections, and date.
-
-The status in the brief and `evidence/SOURCES.md` must match.
+The brief and registry must show the same status and date.
 
 ## Completion checklist
 
 A source may be marked `Verified` only when:
 
-- [ ] The original source and correct version were read.
+- [ ] The correct source version was read.
 - [ ] A reviewed evidence brief exists and is indexed.
 - [ ] Every repository mention and attributed number was located.
 - [ ] A claim-to-source trace exists for all material uses.
 - [ ] Numbers, units, populations, and periods were checked.
 - [ ] Claim strength matches the source design.
-- [ ] Report arguments and nearby conclusions remain valid after corrections.
-- [ ] README tables and diagrams were reassessed.
-- [ ] Protocol implications have an explicit documented outcome.
-- [ ] `Current use` lists actual repository locations.
+- [ ] Report arguments and nearby conclusions remain valid.
+- [ ] README claims, tables, and diagrams were reassessed.
+- [ ] Protocol implications have a documented outcome.
+- [ ] `Current use` lists actual locations.
 - [ ] `REFERENCES.md`, indexes, and links are synchronized.
-- [ ] The brief records the integration status and verification date.
-- [ ] `evidence/SOURCES.md` records `Integration audit = Verified` and the same date.
+- [ ] The brief and registry show matching status and date.
 - [ ] No unresolved correction remains.
 
-Never mark a source `Verified` merely because a brief, citation, or PR exists.
+## PR strategy
 
-## Updating an existing source
+For substantial source work, prefer separate PRs:
 
-When a working paper becomes peer reviewed, a report is revised, a dataset changes, or a relevant repository claim changes:
+1. registration and evidence brief;
+2. report integration and corrections;
+3. README or protocol changes, only when required;
+4. final verification-status update after all required changes exist on the default branch.
 
-1. Set `Evidence review = Needs re-review` when the source itself changed materially.
-2. Set `Integration audit = Needs re-verification` when the source, report use, README diagram, or protocol implication changed materially.
-3. Clear `Last verified` to `—`.
-4. Update the evidence brief and record the new version.
-5. Re-run the entire integration procedure.
-6. Apply corrections.
-7. Restore `Reviewed brief` and `Verified` only after completion.
-8. Record the new verification date.
-
-Do not preserve obsolete numbers silently.
-
-## Evidence-strength rules
-
-- Prefer primary sources over summaries.
-- Prefer official publisher or author links over reposts.
-- Do not infer causality from descriptive evidence without explicit justification.
-- Do not present sentiment or adoption as production impact.
-- Do not treat arXiv or working-paper status as peer review.
-- Do not treat company marketing as independent evidence.
-- Do not use one team's threshold as a universal standard.
-- Preserve null, mixed, contradictory, and positive evidence.
-
-## PR checklist
-
-Before opening or completing a source PR, confirm:
-
-- [ ] The source is registered with both status fields.
-- [ ] Its evidence class is correct.
-- [ ] Publication status and version are explicit.
-- [ ] Findings and repository interpretation are separated.
-- [ ] Evidence-review status matches the actual brief state.
-- [ ] Integration-audit status matches the actual audit state.
-- [ ] All repository uses and attributed numbers were searched.
-- [ ] A claim-to-source trace exists.
-- [ ] Numeric values, units, samples, and periods were checked.
-- [ ] Report language matches the source design.
-- [ ] README claims and diagrams were reassessed.
-- [ ] Protocol implications have an explicit outcome.
-- [ ] `Current use`, `REFERENCES.md`, and indexes are synchronized.
-- [ ] The brief and registry show matching status and date.
-- [ ] Navigation links work.
-- [ ] The PR description lists boundaries, corrections, and unresolved work.
-
-## Preferred PR structure
-
-For a substantial source, use separate PRs when practical:
-
-1. source registration and evidence brief;
-2. report integration and source-wide verification;
-3. repository-map or protocol updates, only when required.
-
-Do not set `Integration audit = Verified` until all required PRs are merged and the repository's default branch reflects the completed state.
+Do not set `Integration audit = Verified` until the default branch reflects the completed state.


### PR DESCRIPTION
## Summary

Replaces the conflict-heavy PR #17 with a clean change created directly from the current `main` branch.

This PR changes only `AGENTS.md` and focuses on one issue: agents must select the correct source workflow before editing repository content.

## What changed

Defines five explicit flows:

- **Flow A** — add a new source;
- **Flow B** — process a legacy registered source;
- **Flow C** — update a changed or superseded source;
- **Flow D** — re-verify repository content when a verified source's use changes;
- **Flow E** — search for newer or missing evidence after the current backlog exposes evidence gaps.

It then separates the shared procedures for:

1. registration and classification;
2. evidence review;
3. repository-wide integration audit;
4. status synchronization;
5. final verification;
6. PR strategy.

## Important state rule

A source is fully processed only when:

```text
Evidence review = Reviewed brief
Integration audit = Verified
```

A brief, citation, merged PR, or corrected paragraph does not imply verified integration.

## Why this PR is intentionally small

PR #17 mixed the intended consistency changes with the old branch history from PR #16, causing many conflicts and a misleading 17-commit diff. This replacement starts from current `main`, contains one commit, and modifies one file.

Entry-point synchronization in `README.md`, `CONTRIBUTING.md`, and protocol navigation should be handled in separate small PRs after this workflow definition is merged.