### PR TITLE
Align contribution and registry navigation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,12 @@ Contributions are welcome from engineers, researchers, delivery leaders, QA and 
 Before contributing, read:
 
 1. [`README.md`](README.md) — repository scope and claim boundaries.
-2. [`evidence/README.md`](evidence/README.md) — evidence taxonomy.
-3. [`evidence/SOURCES.md`](evidence/SOURCES.md) — canonical source registry.
-4. [`AGENTS.md`](AGENTS.md) — end-to-end workflow for sources, report changes, and protocol updates.
+2. [`evidence/README.md`](evidence/README.md) — evidence taxonomy and evidence-brief standard.
+3. [`evidence/SOURCES.md`](evidence/SOURCES.md) — canonical source inventory and status registry.
+4. [`AGENTS.md`](AGENTS.md) — flow selection, evidence review, integration audit, and status transitions.
+5. [`REFERENCES.md`](REFERENCES.md) — compact human-readable bibliography.
+
+`evidence/SOURCES.md` is canonical. `REFERENCES.md` is a bibliography and navigation aid, not a source-status database.
 
 ## Contribution principles
 
@@ -19,21 +22,21 @@ Do not submit unsupported claims, promotional language, or criticism based only 
 
 Good contributions distinguish:
 
-- what was directly observed;
-- what was derived or modeled;
+- what was directly observed or documented;
+- what was derived or model-calibrated;
 - what the source author concluded;
 - what this repository infers;
 - what remains unknown.
 
 ### AI assistance is allowed; unverified output is not
 
-AI tools may be used for search support, outlining, editing, or drafting. The contributor remains responsible for every claim, citation, and link.
+AI tools may be used for search support, outlining, editing, or drafting. The contributor remains responsible for every claim, number, citation, and link.
 
 Do not submit text that has not been checked against the cited source. Remove fabricated citations, generic filler, unsupported certainty, and repetitive model-generated phrasing.
 
 ### Preserve mixed and contradictory evidence
 
-A source does not need to support the Subprime Code Crisis thesis to be included. Positive productivity evidence, null results, critiques, and replications are necessary for a credible synthesis.
+A source does not need to support the Subprime Code Crisis thesis to be included. Positive productivity evidence, null results, critiques, contradictions, and replications are necessary for a credible synthesis.
 
 ### Protect confidential information
 
@@ -47,19 +50,45 @@ For internal case studies:
 
 ## Ways to contribute
 
-### Add or update a source
+### Add, process, or update a source
 
-Follow the source lifecycle in [`AGENTS.md`](AGENTS.md):
+Select the correct primary flow in [`AGENTS.md`](AGENTS.md) before editing source-related content:
 
-1. register the source in `evidence/SOURCES.md`;
-2. classify it;
-3. create an evidence brief;
-4. update the evidence-class index;
-5. integrate it into the report only where relevant;
-6. reassess README-level claims and protocols;
-7. update `REFERENCES.md` last.
+- **Flow A — New source:** the source is not yet registered.
+- **Flow B — Legacy registered source:** the source is already cited or registered but lacks a current reviewed brief or completed integration audit.
+- **Flow C — Changed source:** the source itself changed, was superseded, or changed publication status.
+- **Flow D — Repository use changed:** the source is unchanged, but a claim, diagram, protocol, summary, or calculation relying on it changed materially.
+- **Flow E — Discover newer or missing evidence:** search for stronger, newer, contradictory, positive, null, or replication evidence after real gaps are identified.
 
-Do not add a citation directly to the report without registering it.
+Every registered source has two independent states:
+
+- **Evidence review** — whether the source itself has been reviewed and documented in a current evidence brief.
+- **Integration audit** — whether every material use of that source across the repository has been checked.
+
+A source is fully processed only when:
+
+```text
+Evidence review = Reviewed brief
+Integration audit = Verified
+```
+
+**Reviewed brief does not mean verified integration.** A brief, citation, merged PR, or corrected paragraph does not by itself establish that every repository use has been checked.
+
+For source-related work:
+
+1. select the applicable flow;
+2. register or confirm the source entry in `evidence/SOURCES.md`;
+3. create or update the evidence brief when required;
+4. update the relevant evidence-class index;
+5. run the repository-wide integration audit when required;
+6. build an inspectable claim-to-source trace;
+7. correct report claims and surrounding argument;
+8. reassess README-level claims and diagrams;
+9. document one protocol outcome: no change, clarification, or change;
+10. synchronize `Current use`, indexes, links, and `REFERENCES.md`;
+11. mark integration `Verified` only after all required corrections are merged.
+
+Do not add a citation directly to the report without registering the source.
 
 ### Submit a measured case study
 
@@ -81,9 +110,11 @@ Anecdotes may be useful for hypothesis generation, but must be labeled as anecdo
 
 Report changes should:
 
+- trace material factual claims to registered sources;
 - link to reviewed evidence briefs where possible;
 - distinguish evidence-backed findings from systems inference and warning scenarios;
 - weaken or remove claims when the evidence does not support them;
+- trigger re-verification when a material use of a previously verified source changes;
 - update the claim-confidence map when a major conclusion changes.
 
 ### Improve the protocols
@@ -96,27 +127,31 @@ Protocol changes should explain:
 - required evidence or signals;
 - failure modes;
 - conditions for escalation, pause, or reversal;
-- whether the change is evidence-backed, systems-derived, or a proposed practice.
+- whether the change is evidence-backed, systems-derived, or a proposed practice;
+- which source integrations, if any, require re-verification.
 
 Protocols are adaptable operating patterns, not universal thresholds.
 
 ## Pull-request expectations
 
-A PR should state:
+A source-related PR should state:
 
+- which flow from `AGENTS.md` applies;
 - files changed and why;
 - source IDs affected;
-- claims added, removed, or reclassified;
-- evidence boundaries;
-- what the cited sources do not establish;
-- whether README claims or protocols were reassessed;
-- any unresolved source-quality or link issues.
+- evidence-review and integration-audit states before and after;
+- claims added, removed, corrected, or reclassified;
+- claim-to-source trace location;
+- evidence boundaries and what the sources do not establish;
+- whether README claims, diagrams, or protocols were reassessed;
+- unresolved source-quality, link, or correction issues.
 
-For substantial new evidence, prefer separate PRs for:
+For substantial source work, prefer separate PRs for:
 
 1. registration and evidence brief;
-2. report integration;
-3. repository-map or protocol changes, only when required.
+2. report integration and corrections;
+3. repository-map or protocol changes, only when required;
+4. final verification-status update after all required changes exist on the default branch.
 
 ## License and conduct
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,12 +1,14 @@
 # Bibliography and Data Sources
 
-> **Navigation:** [Home](README.md) | [Evidence Library](evidence/README.md) | [Source Registry](evidence/SOURCES.md) | [Read the Report](report/01_the_illusion.md)
+> **Navigation:** [Home](README.md) | [Evidence Library](evidence/README.md) | [Canonical Source Registry](evidence/SOURCES.md) | [Read the Report](report/01_the_illusion.md)
 
 This file is the compact human-readable bibliography for the repository.
 
-The canonical classification, review status, and report usage for each source live in [`evidence/SOURCES.md`](evidence/SOURCES.md). Detailed source evaluation lives in evidence briefs under `evidence/`.
+[`evidence/SOURCES.md`](evidence/SOURCES.md) is the canonical source inventory and status registry. It records classification, evidence-review status, integration-audit status, verification date, and actual repository use. This bibliography provides readable citations and navigation; it is not a source-status database.
 
-A source appearing here is not automatically peer reviewed, independently validated, or strong enough to support every claim attributed to it. Follow the source-registry and evidence-brief links for boundaries and limitations.
+Detailed source evaluation lives in evidence briefs under `evidence/`.
+
+A source appearing here is not automatically peer reviewed, independently validated, supported by a reviewed brief, or verified across every repository use. Follow the source-registry and evidence-brief links for current status, boundaries, and limitations.
 
 ## Primary empirical research
 
@@ -108,10 +110,11 @@ A source appearing here is not automatically peer reviewed, independently valida
 
 When adding or updating a source:
 
-1. register it in `evidence/SOURCES.md`;
-2. classify it and create or update an evidence brief;
-3. integrate it into the report only where it changes the argument;
-4. reassess README-level claims and protocols;
-5. update this bibliography last.
+1. select the applicable flow in [`AGENTS.md`](AGENTS.md);
+2. register or update it in [`evidence/SOURCES.md`](evidence/SOURCES.md);
+3. create or update the appropriate evidence brief and index;
+4. complete the required repository-wide integration audit;
+5. synchronize actual repository use and verification status in the canonical registry;
+6. update this bibliography last.
 
-See [`AGENTS.md`](AGENTS.md) for the complete workflow.
+Do not infer `Reviewed brief` or `Verified` from a citation appearing here. See [`AGENTS.md`](AGENTS.md) for the complete workflow and [`evidence/SOURCES.md`](evidence/SOURCES.md) for current status.

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -1,6 +1,6 @@
 # 🛡️ Operational Protocols
 
-> **Navigation:** [🏠 Home](../README.md) | [📉 The Report](../report/01_the_illusion.md) | **Protocols** | [📚 References](../REFERENCES.md)
+> **Navigation:** [🏠 Home](../README.md) | [📉 The Report](../report/01_the_illusion.md) | **Protocols** | [🧾 Evidence Library](../evidence/README.md) | [📋 Source Registry](../evidence/SOURCES.md) | [📚 References](../REFERENCES.md)
 
 ## From diagnosis to operating practice
 
@@ -116,10 +116,17 @@ The reverse sequence is a common failure mode: executives announce broad adoptio
 
 These protocols are derived from the report's risk analysis and evidence synthesis. They should be evaluated through implementation feedback, local measurement, and further empirical study.
 
+- The [Source Registry](../evidence/SOURCES.md) is the canonical source inventory and status registry. It records evidence-review status, integration-audit status, verification date, and actual repository use.
 - The [Evidence Library](../evidence/README.md) documents source classes and evidence briefs.
+- [References](../REFERENCES.md) is the compact human-readable bibliography; it is not the canonical inventory or status database.
 - The [Claim confidence map](../README.md#claim-confidence-map) identifies the current support level of major repository claims.
-- [References](../REFERENCES.md) remains the complete bibliography and compact source inventory.
 - [Uncertainty Architecture](https://github.com/UncertaintyArchitectureGroup/uncertainty-architecture) provides a broader specification for governing non-deterministic systems; it complements this repository but does not replace these software-delivery protocols.
+
+A protocol may be motivated by one or more sources, but it is not empirical proof. During a source integration audit, protocol implications must be recorded as exactly one of:
+
+- **No protocol change**
+- **Protocol clarification**
+- **Protocol change**
 
 ---
 


### PR DESCRIPTION
## Summary

Synchronizes the repository's contribution and navigation entry points with the source-state model already defined in `AGENTS.md`.

This is intentionally a narrow follow-up to PR #18. It changes only:

- `CONTRIBUTING.md`
- `REFERENCES.md`
- `protocols/README.md`

## Canonical roles

All three files now state consistently:

```text
evidence/SOURCES.md = canonical source inventory and status registry
REFERENCES.md = compact human-readable bibliography
```

`REFERENCES.md` is explicitly not treated as a status database.

## CONTRIBUTING.md

Adds:

- the Flow A–E selector from `AGENTS.md`;
- the two independent source states:
  - Evidence review
  - Integration audit
- the completion rule:

```text
Evidence review = Reviewed brief
Integration audit = Verified
```

- the explicit boundary:

```text
Reviewed brief does not mean verified integration
```

- source-related PR expectations, including state transitions, claim-to-source trace, README/diagram reassessment, protocol outcome, and final verification after merge.

## REFERENCES.md

Clarifies that:

- it is a readable bibliography and navigation aid;
- current classification, review status, integration status, verification date, and actual use belong in `evidence/SOURCES.md`;
- a citation appearing in the bibliography does not imply a reviewed brief or verified integration.

## protocols/README.md

Adds direct navigation to the Evidence Library and Source Registry, removes the claim that References is the complete source inventory, and records the required protocol-audit outcomes:

- No protocol change
- Protocol clarification
- Protocol change

## Scope boundary

This PR does not change:

- `AGENTS.md`;
- report claims;
- source statuses;
- evidence briefs;
- the root README or Crisis Map.

Those remain separate workstreams.