### PR TITLE
Synchronize repository instructions and canonical references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,14 @@ This repository is an independent research synthesis and operational guidance pr
 
 Contributions are welcome from engineers, researchers, delivery leaders, QA and security practitioners, and organizations willing to publish inspectable results.
 
-Before contributing, read:
+Read [`AGENTS.md`](AGENTS.md) first.
 
-1. [`README.md`](README.md) — repository scope and claim boundaries.
-2. [`evidence/README.md`](evidence/README.md) — evidence taxonomy and evidence-brief standard.
-3. [`evidence/SOURCES.md`](evidence/SOURCES.md) — canonical source inventory and status registry.
-4. [`AGENTS.md`](AGENTS.md) — flow selection, evidence review, integration audit, and status transitions.
-5. [`REFERENCES.md`](REFERENCES.md) — compact human-readable bibliography.
+Then follow the mandatory start-of-work read order defined there. The following links are supporting entry points, not a competing canonical sequence:
+
+- [`README.md`](README.md) — repository scope and claim boundaries.
+- [`evidence/README.md`](evidence/README.md) — evidence taxonomy and evidence-brief standard.
+- [`evidence/SOURCES.md`](evidence/SOURCES.md) — canonical source inventory and status registry.
+- [`REFERENCES.md`](REFERENCES.md) — compact human-readable bibliography and navigation aid.
 
 `evidence/SOURCES.md` is canonical. `REFERENCES.md` is a bibliography and navigation aid, not a source-status database.
 
@@ -84,9 +85,11 @@ For source-related work:
 6. build an inspectable claim-to-source trace;
 7. correct report claims and surrounding argument;
 8. reassess README-level claims and diagrams;
-9. document one protocol outcome: no change, clarification, or change;
+9. document exactly one protocol outcome: `No protocol change`, `Protocol clarification`, or `Protocol change proposed`;
 10. synchronize `Current use`, indexes, links, and `REFERENCES.md`;
-11. mark integration `Verified` only after all required corrections are merged.
+11. pass independent review;
+12. resolve all corrections;
+13. mark integration `Verified` only when the independent-review outcome is `Confirmed` and all required corrections exist on the default branch.
 
 Do not add a citation directly to the report without registering the source.
 
@@ -150,8 +153,9 @@ For substantial source work, prefer separate PRs for:
 
 1. registration and evidence brief;
 2. report integration and corrections;
-3. repository-map or protocol changes, only when required;
-4. final verification-status update after all required changes exist on the default branch.
+3. README or protocol changes, only when required and approved;
+4. independent-review corrections, when required;
+5. final verification-status update after the complete state exists on the default branch.
 
 ## License and conduct
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The **Claim confidence map** evaluates the repository's conclusions: what kind o
 
 The **Evidence Map** classifies the materials used to build those claims. It answers a different question from the Claim confidence map: not *how confident are we in a claim?*, but *what kind of source, interpretation, or operational artifact is this?*
 
-The table below is a repository-level map, not a replacement for the complete [Bibliography & Data Sources](REFERENCES.md). It names the current source families and the major sources already used in the report.
+The table below is a repository-level map, not a replacement for the canonical source inventory and status registry in [`evidence/SOURCES.md`](evidence/SOURCES.md). [`REFERENCES.md`](REFERENCES.md) remains a compact human-readable bibliography and navigation aid.
 
 | Layer | Purpose | Current coverage in this repository |
 | --- | --- | --- |
@@ -121,7 +121,7 @@ The evidence flow is intentionally directional:
 4. **The report develops bounded findings, inferences, and risk scenarios.**
 5. **Protocols translate those risks into operating practices.**
 
-A protocol is therefore not empirical proof, a repository interpretation is not a finding directly reported by a source, and a confidence rating is not a source category. Detailed classification rules and evidence-brief standards are documented in the [Evidence Library](evidence/README.md); the complete source inventory remains in [References](REFERENCES.md).
+A protocol is therefore not empirical proof, a repository interpretation is not a finding directly reported by a source, and a confidence rating is not a source category. Detailed classification rules and evidence-brief standards are documented in the [Evidence Library](evidence/README.md). The canonical source inventory and status registry is [`evidence/SOURCES.md`](evidence/SOURCES.md); [`REFERENCES.md`](REFERENCES.md) is the compact human-readable bibliography and navigation aid.
 
 ## 📊 The Crisis Map
 
@@ -166,7 +166,7 @@ It can be read in three ways:
 - As a delivery-system analysis of bottleneck migration.
 - As a starting point for engineering governance patterns around AI-generated code.
 
-Readers looking for the evidence base should start with the [Evidence Library](evidence/README.md) and then use [References](REFERENCES.md) as the complete bibliography and compact source index.
+Readers looking for the evidence base should start with the [Evidence Library](evidence/README.md), use the canonical [Source Registry](evidence/SOURCES.md) for inventory and status, and use [References](REFERENCES.md) as the compact human-readable bibliography and navigation aid.
 
 Readers looking for immediate operating practices should start with the [Operational Protocols](protocols/README.md).
 ## 📂 Report Structure

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -80,6 +80,7 @@ Each evidence brief should include:
 11. Limitations, conflicts, and external-validity risks.
 12. Repository locations using the source.
 13. A `Repository integration audit` section matching the status in `SOURCES.md`.
+14. An `Independent review` section matching the outcome required by `AGENTS.md`.
 
 Use this audit template:
 
@@ -91,10 +92,26 @@ Use this audit template:
 - Report mentions checked:
 - Numeric claims checked:
 - README claims and diagrams checked:
-- Protocol outcome: No change | Clarification | Operational change
+- Protocol outcome: No protocol change | Protocol clarification | Protocol change proposed
 - Corrections made:
 - Current-use locations confirmed:
 - Verification date:
+```
+
+Use this independent-review template:
+
+```markdown
+## Independent review
+
+- Primary agent or reviewer:
+- Independent reviewer:
+- Flow reviewed:
+- Materials independently checked:
+- Outcome: Confirmed | Corrections required | Unresolved disagreement | Review unavailable
+- Discrepancies found:
+- Corrections completed:
+- Human decision required:
+- Review date:
 ```
 
 ## Interpretation labels
@@ -118,4 +135,4 @@ Do not mark a source `Verified` merely because:
 - a PR was merged;
 - a report paragraph was corrected.
 
-`Verified` requires the complete repository-wide procedure in `AGENTS.md`, synchronized status in the brief and `SOURCES.md`, and a recorded verification date.
+`Verified` requires the complete repository-wide procedure in `AGENTS.md`, synchronized status in the brief and `SOURCES.md`, a `Confirmed` independent-review outcome, and a recorded verification date.

--- a/evidence/SOURCES.md
+++ b/evidence/SOURCES.md
@@ -57,7 +57,7 @@ Documentary and methodology sources use the same review lifecycle. Their briefs 
 | ID | Source | Evidence review | Integration audit | Last verified | Can support | Current use |
 | --- | --- | --- | --- | --- | --- | --- |
 | **S-2025-01** | Deloitte, *State of Generative AI in the Enterprise* | Registered | Not started | — | Surveyed enterprise adoption, expectations, and reported constraints | Adoption and organizational-context discussion |
-| **S-2025-02** | McKinsey enterprise AI reporting, currently linked through a third-party summary | Registered; original source required | Not started | — | Context on reported adoption and impact; not load-bearing until the original report is linked and reviewed | Market-sentiment discussion |
+| **S-2025-02** | McKinsey enterprise AI reporting, currently linked through a third-party summary | Registered | Not started | — | Context only until the original McKinsey publication is identified, registered, and reviewed | Market-sentiment discussion |
 | **S-2025-03** | Artur Markus, *The Inference Cost Paradox* | Registered | Not started | — | Practitioner interpretation of enterprise AI spending and Jevons-style effects | Cost-paradox discussion |
 | **S-2026-01** | Andreas Horn, *The Most Important Chart in AI* | Registered | Not started | — | Practitioner framing and visual interpretation | Market and capability narrative context |
 | **S-2025-04** | SoftwareSeni, *Why AI Coding Speed Gains Disappear in Code Reviews* | Registered | Not started | — | Practitioner synthesis about review bottlenecks | Review-bottleneck framing |
@@ -79,7 +79,7 @@ Dataset registry entries must use the same `Evidence review`, `Integration audit
 
 1. Register a source before adding it to the report.
 2. Set `Evidence review` to `Reviewed brief` only after a source-oriented brief exists and is indexed.
-3. Set `Integration audit` to `Verified` only after completing every step in **Verifying the integration of each source** in `AGENTS.md`.
+3. Set `Integration audit` to `Verified` only after completing every step in the **Integration-audit procedure** in `AGENTS.md`.
 4. Never infer `Verified` from the existence of a brief, citation, or prior PR.
 5. Record the verification date only when the status becomes `Verified`.
 6. If a source version changes, set `Evidence review` to `Needs re-review` and `Integration audit` to `Needs re-verification` until both procedures are rerun.

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -126,7 +126,7 @@ A protocol may be motivated by one or more sources, but it is not empirical proo
 
 - **No protocol change**
 - **Protocol clarification**
-- **Protocol change**
+- **Protocol change proposed**
 
 ---
 


### PR DESCRIPTION
## Summary

Synchronizes supporting repository documents with the already-canonical rules in `AGENTS.md`.

This is a consistency and terminology PR. It does not modify `AGENTS.md`, repository arguments, evidence interpretation, or protocol logic.

## Start-of-work classification

- **Primary flow:** Supporting-document synchronization; no source Flow A–E state transition is required.
- **Files in scope:** `README.md`, `CONTRIBUTING.md`, `evidence/README.md`, `evidence/SOURCES.md`, `protocols/README.md`.
- **Source IDs affected:** `S-2025-02` metadata correction only.
- **Evidence review / integration audit:** Not required; no evidence interpretation or source use changed.
- **Substantive-change trigger:** No. Changes reproduce already-approved canonical rules and allowed enums from `AGENTS.md`.

## Changes

### AGENTS-first contributor order

`CONTRIBUTING.md` now instructs contributors to read `AGENTS.md` first and follow the mandatory start-of-work order defined there. Supporting links remain available without competing with the canonical sequence.

### Canonical source roles

`README.md` now consistently defines:

```text
evidence/SOURCES.md = canonical source inventory and status registry
REFERENCES.md = compact human-readable bibliography and navigation aid
```

Statements describing `REFERENCES.md` as the complete inventory, status source, or complete bibliography were removed.

### Evidence brief standard

`evidence/README.md` now requires an `Independent review` section and includes the canonical review template and outcomes from `AGENTS.md`.

### Protocol outcomes

All touched documents now use exactly:

- `No protocol change`
- `Protocol clarification`
- `Protocol change proposed`

The word `proposed` is retained because substantive protocol modification requires human approval.

### Source registry corrections

For `S-2025-02`:

- `Evidence review` is now the valid enum `Registered`;
- the original-source limitation moved to `Can support`;
- the obsolete section reference was replaced with `Integration-audit procedure`.

### Contributor completion and PR sequence

`CONTRIBUTING.md` now requires independent review, correction resolution, and a `Confirmed` outcome before `Verified` status. Its PR sequence now matches `AGENTS.md`, including independent-review corrections and the final default-branch verification update.

## Scope boundary

This PR does not change:

- Flow A–E;
- Repository Constitution;
- report claims or evidence interpretations;
- Crisis Map or claim-confidence levels;
- protocol controls, roles, thresholds, gates, or escalation logic;
- `AGENTS.md`.

## Verification

- Diff is limited to the five declared supporting files.
- All source-state values in the touched registry use allowed enums.
- Protocol outcome terminology matches `AGENTS.md`.
- `evidence/SOURCES.md` is consistently identified as canonical.
- Contributor instructions now include independent review.